### PR TITLE
Drop DRF from dependencies

### DIFF
--- a/rele/client.py
+++ b/rele/client.py
@@ -1,10 +1,10 @@
+import json
 import logging
 from contextlib import suppress
 
 from django.conf import settings
 from google.api_core import exceptions
 from google.cloud import pubsub_v1
-from rest_framework.renderers import JSONRenderer
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ class Publisher(metaclass=_PublisherSingleton):
             credentials=settings.RELE_GC_CREDENTIALS)
 
     def publish(self, topic, data, **attrs):
-        data = JSONRenderer().render(data)
+        data = json.dumps(data).encode()
         logger.info(f'Publishing to {topic}',
                     extra={'pubsub_publisher_data': data})
         topic_path = self._client.topic_path(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 django
-djangorestframework
 google-cloud-pubsub

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,4 +18,4 @@ class TestPublisher:
 
         assert result is True
         publisher._client.publish.assert_called_with(
-            ANY, b'{"foo":"bar"}', event_type='cancellation')
+            ANY, b'{"foo": "bar"}', event_type='cancellation')


### PR DESCRIPTION
DRF was used for deserializing to JSON, this can be achieved by using standard python.