### PR TITLE
Respect PUBSUB_EMULATOR_HOST env var

### DIFF
--- a/rele/client.py
+++ b/rele/client.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from contextlib import suppress
 
 from django.conf import settings
@@ -8,12 +9,17 @@ from rest_framework.renderers import JSONRenderer
 
 logger = logging.getLogger(__name__)
 
+USE_EMULATOR = True if os.environ.get('PUBSUB_EMULATOR_HOST') else False
+
 
 class Subscriber:
 
     def __init__(self):
-        self._client = pubsub_v1.SubscriberClient(
-            credentials=settings.RELE_GC_CREDENTIALS)
+        if USE_EMULATOR:
+            self._client = pubsub_v1.SubscriberClient()
+        else:
+            self._client = pubsub_v1.SubscriberClient(
+                credentials=settings.RELE_GC_CREDENTIALS)
 
     def create_subscription(self, subscription, topic):
         subscription_path = self._client.subscription_path(
@@ -35,13 +41,18 @@ class Publisher:
     PUBLISH_TIMEOUT = 3.0
 
     def __init__(self):
-        self._client = pubsub_v1.PublisherClient(
-            credentials=settings.RELE_GC_CREDENTIALS)
+        if USE_EMULATOR:
+            self._client = pubsub_v1.PublisherClient()
+        else:
+            self._client = pubsub_v1.PublisherClient(
+                credentials=settings.RELE_GC_CREDENTIALS)
 
     def publish(self, topic, data, blocking=False, **attrs):
         data = JSONRenderer().render(data)
-        logger.info(f'Publishing to {topic}', extra={'pubsub_publisher_data': data})
-        topic_path = self._client.topic_path(settings.RELE_GC_PROJECT_ID, topic)
+        logger.info(f'Publishing to {topic}',
+                    extra={'pubsub_publisher_data': data})
+        topic_path = self._client.topic_path(
+            settings.RELE_GC_PROJECT_ID, topic)
         future = self._client.publish(topic_path, data, **attrs)
         if not blocking:
             return future


### PR DESCRIPTION
### :tophat: What?

Don't provide credentials when PUBSUB_EMULATOR_HOST is set in the environment.

### :thinking: Why?

So we can use the Google Pub/Sub emulator
