### PR TITLE
Parse as None an empty message

### DIFF
--- a/rele/client.py
+++ b/rele/client.py
@@ -48,12 +48,12 @@ class Publisher:
                 credentials=settings.RELE_GC_CREDENTIALS)
 
     def publish(self, topic, data, blocking=False, **attrs):
-        data = JSONRenderer().render(data)
+        payload = JSONRenderer().render(data)
         logger.info(f'Publishing to {topic}',
                     extra={'pubsub_publisher_attrs': attrs})
         topic_path = self._client.topic_path(
             settings.RELE_GC_PROJECT_ID, topic)
-        future = self._client.publish(topic_path, data, **attrs)
+        future = self._client.publish(topic_path, payload, **attrs)
         if not blocking:
             return future
 

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -34,8 +34,11 @@ class Callback:
         db.close_old_connections()
 
         logger.debug(f'Start processing message for {self._subscription}',
-                    extra=self._build_metrics())
-        data = json.loads(message.data.decode('utf-8'))
+                     extra=self._build_metrics())
+        if message.data == b'':
+            data = None
+        else:
+            data = json.loads(message.data.decode('utf-8'))
         try:
             self._subscription(data, **dict(message.attributes))
         except Exception as e:


### PR DESCRIPTION
### :tophat: What?

Parse  `b''` as `None`

### :thinking: Why?

It cannot be deserialized as JSON.
