### PR TITLE
Use drf jsonencoder, not renderer

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,7 @@ class TestPublisher:
 
         assert isinstance(result, concurrent.futures.Future)
         publisher._client.publish.assert_called_with(
-            ANY, b'{"foo":"bar"}', myattr='hello')
+            ANY, b'{"foo": "bar"}', myattr='hello')
 
     def test_save_log_when_published_called(self, caplog):
         message = {'foo': 'bar'}

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -126,15 +126,3 @@ class TestCallback:
                 'duration_seconds': pytest.approx(0.5, abs=0.5)
             }
         }
-
-    def test_sets_data_none_when_data_empty(
-            self, caplog, message_wrapper_empty):
-
-        @sub(topic='some-cool-topic')
-        def some_sub_stub(data, **kwargs):
-            return data if data is None else False
-
-        callback = Callback(some_sub_stub)
-        res = callback(message_wrapper_empty)
-
-        assert res is None


### PR DESCRIPTION
### :tophat: What?

Use json.dumps with drf's encoder, not the whole renderer.

### :thinking: Why?

It was simply incorrect. For example `.render(None)` was an empty string, which is not valid JSON.