### PR TITLE
Add task to install development dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,5 +47,11 @@ install-deploy-requirements:  ## install requirements for deployment
 install-docs-requirements:  ## install requirements for documentation
 	pip install -r requirements/docs.txt
 
+install-dev-requirements:
+	pip install -r requirements/base.txt
+	pip install -r requirements/test.txt
+	pip install -r requirements/docs.txt
+
+
 build-html-doc:
 	DJANGO_SETTINGS_MODULE=tests.settings make html -C docs

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -93,7 +93,7 @@ def sub(topic, suffix=None):
     Additionally, if a `suffix` param is added, the subscriber will be
     `project-name-lets-tell-everyone-my-suffix`.
 
-    It is recommended to add **kwargs to your `sub` function. This will allow
+    It is recommended to add `**kwargs` to your `sub` function. This will allow
     message attributes to be sent without breaking the subscriber implementation.
 
     Usage::


### PR DESCRIPTION
### :tophat: What?

* Fix warning converting docstring for **kwargs
* Add task `make install-dev-requirements` to install all dependencies for development

### :thinking: Why?

* Remove warning when generating the html documentation
* To run just one command to install all necessary dependencies for development
