### PR TITLE
Setup github pages to work off docs/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 `0.3.1` (2019-06-04)
 
-* Add promethous metrics key to logs (#16 - #20, #22, #23)
+* Add prometheus metrics key to logs (#16 - #20, #22, #23)
 * Fix JSON serialization when publishing (#25)
 
 `0.3.0` (2019-05-14)


### PR DESCRIPTION
### :tophat: What?

Serve github pages off `docs/` dir.

