### PR TITLE
Add timestamp to published message

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,9 +40,10 @@ Modules
 _______
 
 .. toctree::
-   :maxdepth: 2
+    :maxdepth: 2
 
-   subscription
+    subscription
+    modules/client
 
 .. toctree::
    :maxdepth: 2

--- a/docs/modules/client.rst
+++ b/docs/modules/client.rst
@@ -1,0 +1,11 @@
+.. _ client
+
+Client
+======
+
+.. automodule:: rele
+   :members:
+
+.. autoclass:: rele.client.Publisher
+   :members:
+

--- a/rele/client.py
+++ b/rele/client.py
@@ -49,7 +49,7 @@ class Publisher:
             self._client = pubsub_v1.PublisherClient(credentials=credentials)
 
     def publish(self, topic, data, blocking=False, **attrs):
-        """Publish data to Pub/Sub.
+        """Publishes data to Pub/Sub adding a timestamp `published_at` to the attrs.
 
         Usage::
 

--- a/rele/client.py
+++ b/rele/client.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 from contextlib import suppress
 
 from django.conf import settings
@@ -48,6 +49,8 @@ class Publisher:
             self._client = pubsub_v1.PublisherClient(credentials=credentials)
 
     def publish(self, topic, data, blocking=False, **attrs):
+        attrs['published_at'] = str(time.time())
+
         logger.info(f'Publishing to {topic}',
                     extra={
                         'pubsub_publisher_attrs': attrs,

--- a/rele/client.py
+++ b/rele/client.py
@@ -48,7 +48,7 @@ class Publisher:
         else:
             self._client = pubsub_v1.PublisherClient(credentials=credentials)
 
-    def publish(self, topic, data, published_at=None, blocking=False, **attrs):
+    def publish(self, topic, data, blocking=False, **attrs):
         """Publish data to Pub/Sub.
 
         Usage::
@@ -58,13 +58,12 @@ class Publisher:
 
         :param topic: string topic to publish the data.
         :param data: dict with the content of the message.
-        :param published_at: string, default None.
         :param blocking: boolean, default False.
         :param attrs: Extra parameters to be published.
         :return: future
         """
 
-        attrs['published_at'] = published_at or str(time.time())
+        attrs['published_at'] = str(time.time())
 
         logger.info(f'Publishing to {topic}',
                     extra={

--- a/rele/client.py
+++ b/rele/client.py
@@ -48,8 +48,23 @@ class Publisher:
         else:
             self._client = pubsub_v1.PublisherClient(credentials=credentials)
 
-    def publish(self, topic, data, blocking=False, **attrs):
-        attrs['published_at'] = str(time.time())
+    def publish(self, topic, data, published_at=None, blocking=False, **attrs):
+        """Publish data to Pub/Sub.
+
+        Usage::
+
+            publisher = Publisher()
+            publisher.publish('topic_name', {'foo': 'bar'})
+
+        :param topic: string topic to publish the data.
+        :param data: dict with the content of the message.
+        :param published_at: string, default None.
+        :param blocking: boolean, default False.
+        :param attrs: Extra parameters to be published.
+        :return: future
+        """
+
+        attrs['published_at'] = published_at or str(time.time())
 
         logger.info(f'Publishing to {topic}',
                     extra={

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -28,6 +28,9 @@ class Subscription:
         self._prefix = prefix
 
     def __call__(self, data, **kwargs):
+        if 'published_at' in kwargs:
+            kwargs['published_at'] = float(kwargs['published_at'])
+
         self._func(data, **kwargs)
 
     def __str__(self):
@@ -49,6 +52,7 @@ class Callback:
                          'metrics': self._build_metrics('received')
                      })
         data = json.loads(message.data.decode('utf-8'))
+
         try:
             self._subscription(data, **dict(message.attributes))
         except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+import concurrent
+from unittest.mock import MagicMock
+from google.cloud.pubsub_v1 import PublisherClient
+from rele import Publisher
+
+
+@pytest.fixture(scope='class')
+def publisher():
+    publisher = Publisher()
+    publisher._client = MagicMock(spec=PublisherClient)
+    publisher._client.publish.return_value = concurrent.futures.Future()
+
+    return publisher

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,13 @@ import concurrent
 from unittest.mock import MagicMock
 from google.cloud.pubsub_v1 import PublisherClient
 from rele import Publisher
+from tests import settings
 
 
 @pytest.fixture(scope='class')
 def publisher():
-    publisher = Publisher()
+    publisher = Publisher(settings.RELE_GC_PROJECT_ID,
+                          settings.RELE_GC_CREDENTIALS)
     publisher._client = MagicMock(spec=PublisherClient)
     publisher._client.publish.return_value = concurrent.futures.Future()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 import concurrent
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from google.cloud.pubsub_v1 import PublisherClient
 from rele import Publisher
 from tests import settings
@@ -14,3 +14,15 @@ def publisher():
     publisher._client.publish.return_value = concurrent.futures.Future()
 
     return publisher
+
+
+@pytest.fixture
+def published_at():
+    return 1560244246.863829
+
+
+@pytest.fixture
+def time_mock(published_at):
+    with patch('time.time') as mock:
+        mock.return_value = published_at
+        yield mock

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,8 +2,6 @@ import pytest
 import concurrent
 from unittest.mock import ANY, patch
 
-from . import settings
-
 
 @pytest.mark.usefixtures('publisher')
 class TestPublisher:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,21 +14,22 @@ class TestPublisher:
     def setup_method(cls):
         cls.publisher = Publisher()
         cls.publisher._client = MagicMock(spec=PublisherClient)
-        cls.publisher._client.publish.return_value = concurrent.futures.Future()
+        cls.publisher._client.publish\
+                             .return_value = concurrent.futures.Future()
 
     @patch('time.time', return_value=1560244246.863829)
     def test_returns_future_when_published_called(self, mocked_time):
         message = {'foo': 'bar'}
         result = self.publisher.publish(topic='order-cancelled',
-                                   data=message,
-                                   myattr='hello')
+                                        data=message,
+                                        myattr='hello')
 
         assert isinstance(result, concurrent.futures.Future)
 
-        self.publisher._client.publish.assert_called_with(ANY,
-                                                          b'{"foo": "bar"}',
-                                                          myattr='hello',
-                                                          published_at='1560244246.863829')
+        self.publisher._client.publish.assert_called_with(
+            ANY, b'{"foo": "bar"}',
+            myattr='hello',
+            published_at='1560244246.863829')
 
     @patch('time.time', return_value=1560244246.863829)
     def test_save_log_when_published_called(self, mocked_time, caplog):
@@ -61,6 +62,5 @@ class TestPublisher:
                                data=message,
                                published_at=expected_time)
 
-        self.publisher._client.publish.assert_called_with(ANY,
-                                                          b'{"foo": "bar"}',
-                                                          published_at=expected_time)
+        self.publisher._client.publish.assert_called_with(
+            ANY, b'{"foo": "bar"}', published_at=expected_time)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,12 +1,12 @@
 import pytest
 import concurrent
-from unittest.mock import ANY, patch
+from unittest.mock import ANY
 
 
-@pytest.mark.usefixtures('publisher')
+@pytest.mark.usefixtures('publisher', 'time_mock')
 class TestPublisher:
-    @patch('time.time', return_value=1560244246.863829)
-    def test_returns_future_when_published_called(self, _time, publisher):
+    def test_returns_future_when_published_called(
+            self, published_at, publisher):
         message = {'foo': 'bar'}
         result = publisher.publish(topic='order-cancelled',
                                    data=message,
@@ -18,10 +18,10 @@ class TestPublisher:
             ANY,
             b'{"foo": "bar"}',
             myattr='hello',
-            published_at='1560244246.863829')
+            published_at=str(published_at))
 
-    @patch('time.time', return_value=1560244246.863829)
-    def test_save_log_when_published_called(self, _time, publisher, caplog):
+    def test_save_log_when_published_called(
+            self, published_at, publisher, caplog):
         message = {'foo': 'bar'}
 
         publisher.publish(topic='order-cancelled',
@@ -33,7 +33,7 @@ class TestPublisher:
         assert log.message == 'Publishing to order-cancelled'
         assert log.pubsub_publisher_attrs == {
             'myattr': 'hello',
-            'published_at': '1560244246.863829'
+            'published_at': str(published_at)
         }
         assert log.metrics == {
             'name': 'publications',
@@ -43,9 +43,8 @@ class TestPublisher:
             }
         }
 
-    @patch('time.time', return_value=1560244246.863829)
-    def test_publish_sets_published_at(self, _time, publisher):
+    def test_publish_sets_published_at(self, published_at, publisher):
         publisher.publish(topic='order-cancelled', data={'foo': 'bar'})
 
         publisher._client.publish.assert_called_with(
-            ANY, b'{"foo": "bar"}', published_at='1560244246.863829')
+            ANY, b'{"foo": "bar"}', published_at=str(published_at))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 import concurrent
-from unittest.mock import ANY, MagicMock
+import time
+from unittest.mock import ANY, MagicMock, patch
 
 from google.cloud.pubsub_v1 import PublisherClient
 
@@ -9,34 +10,41 @@ from . import settings
 
 
 class TestPublisher:
+    @classmethod
+    def setup_method(cls):
+        cls.publisher = Publisher()
+        cls.publisher._client = MagicMock(spec=PublisherClient)
+        cls.publisher._client.publish.return_value = concurrent.futures.Future()
 
-    def test_returns_future_when_published_called(self):
+    @patch('time.time', return_value=1560244246.863829)
+    def test_returns_future_when_published_called(self, mocked_time):
         message = {'foo': 'bar'}
-        publisher = Publisher(settings.RELE_GC_PROJECT_ID,
-                              settings.RELE_GC_CREDENTIALS)
-        publisher._client = MagicMock(spec=PublisherClient)
-        publisher._client.publish.return_value = concurrent.futures.Future()
-
-        result = publisher.publish(topic='order-cancelled',
+        result = self.publisher.publish(topic='order-cancelled',
                                    data=message,
                                    myattr='hello')
 
         assert isinstance(result, concurrent.futures.Future)
-        publisher._client.publish.assert_called_with(
-            ANY, b'{"foo": "bar"}', myattr='hello')
 
-    def test_save_log_when_published_called(self, caplog):
+        self.publisher._client.publish.assert_called_with(ANY,
+                                                          b'{"foo": "bar"}',
+                                                          myattr='hello',
+                                                          published_at='1560244246.863829')
+
+    @patch('time.time', return_value=1560244246.863829)
+    def test_save_log_when_published_called(self, mocked_time, caplog):
         message = {'foo': 'bar'}
-        publisher = Publisher(1, settings.RELE_GC_CREDENTIALS)
-        publisher._client = MagicMock(spec=PublisherClient)
-        publisher._client.publish.return_value = concurrent.futures.Future()
 
-        publisher.publish(topic='order-cancelled',
-                          data=message,
-                          myattr='hello')
+        self.publisher.publish(topic='order-cancelled',
+                               data=message,
+                               myattr='hello')
+
         log = caplog.records[0]
+
         assert log.message == 'Publishing to order-cancelled'
-        assert log.pubsub_publisher_attrs == {'myattr': 'hello'}
+        assert log.pubsub_publisher_attrs == {
+            'myattr': 'hello',
+            'published_at': '1560244246.863829'
+        }
         assert log.metrics == {
             'name': 'publications',
             'data': {
@@ -44,3 +52,15 @@ class TestPublisher:
                 'topic': 'order-cancelled',
             }
         }
+
+    def test_set_published_at_as_argument(self):
+        message = {'foo': 'bar'}
+        expected_time = str(time.time())
+
+        self.publisher.publish(topic='order-cancelled',
+                               data=message,
+                               published_at=expected_time)
+
+        self.publisher._client.publish.assert_called_with(ANY,
+                                                          b'{"foo": "bar"}',
+                                                          published_at=expected_time)

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -21,6 +21,7 @@ def sub_fancy_stub(data, **kwargs):
     logger.info(f'I used to have a prefix, but not anymore, only {data["id"]}'
                 f'id {kwargs["lang"]}')
 
+
 @sub(topic='published-time-type')
 def sub_published_time_type(data, **kwargs):
     logger.info(f'{type(kwargs["published_at"])}')


### PR DESCRIPTION
### :tophat: What?

* Add optional parameter published_at  to publish function, it uses `time.time()` in case published_at is None.
* client.Publisher documentation page.

### Screenshot

<img width="1224" alt="Screenshot 2019-06-11 at 14 46 56" src="https://user-images.githubusercontent.com/52708/59273296-2064d300-8c58-11e9-8483-8e60879eac68.png">

### :thinking: Why?

It can be useful to have the time that the message was published.
