### PR TITLE
Subscriber prefix param

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ INSTALLED_APPS = [
 You'll also need to set up two variables with the Google Cloud credentials:
 `RELE_GC_CREDENTIALS` and `RELE_GC_PROJECT_ID`.
 
+You can use `RELE_SUB_PREFIX` to add a prefix to all your subscription names, for
+example, with your project name.
+
 NOTE: Ensure that [`CONN_MAX_AGE`](https://docs.djangoproject.com/en/2.2/ref/settings/#conn-max-age)
 is set to 0 in your worker. The Django default value is 0.
 
@@ -75,6 +78,17 @@ from rele import sub
 def sub_function(data, **kwargs):
       event = kwargs.get('myevent')
       print(f'I am a task doing stuff with an event: {event}')
+```
+
+#### Subscription `prefix`
+
+An optional prefix to the subscription name. Useful to namespace your subscription
+with your project name.
+
+```python
+@sub(topic='lets-tell-everyone', prefix='my-project')
+def purpose_1(data, **kwargs):
+     pass
 ```
 
 #### Subscription `suffix`

--- a/README.md
+++ b/README.md
@@ -80,17 +80,6 @@ def sub_function(data, **kwargs):
       print(f'I am a task doing stuff with an event: {event}')
 ```
 
-#### Subscription `prefix`
-
-An optional prefix to the subscription name. Useful to namespace your subscription
-with your project name.
-
-```python
-@sub(topic='lets-tell-everyone', prefix='my-project')
-def purpose_1(data, **kwargs):
-     pass
-```
-
 #### Subscription `suffix`
 
 In order for multiple subscriptions to consume from the same topic, you'll want to add

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -52,6 +52,8 @@ class Command(BaseCommand):
             for attr_name in dir(sub_module):
                 attribute = getattr(sub_module, attr_name)
                 if isinstance(attribute, Subscription):
+                    if settings.RELE_PREFIX and not attribute.prefix:
+                        attribute.set_prefix(settings.RELE_SUB_PREFIX)
                     subscriptions.append(attribute)
         return subscriptions
 

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -107,6 +107,10 @@ def sub(topic, prefix=None, suffix=None):
 
     Usage::
 
+        @sub(topic='lets-tell-to-alice', prefix='shop')
+        def bob_purpose(data, **kwargs):
+             pass
+
         @sub(topic='lets-tell-everyone', suffix='sub1')
         def purpose_1(data, **kwargs):
              pass

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -12,13 +12,23 @@ class Subscription:
     def __init__(self, func, topic, prefix=None, suffix=None):
         self._func = func
         self.topic = topic
-        self.prefix = prefix
-        self.name = ''
-        if self.prefix:
-            self.name = f'{self.prefix}-'
-        self.name += topic
-        if suffix:
-            self.name += f'-{suffix}'
+        self._prefix = prefix or ''
+        self._suffix = suffix or ''
+
+    @property
+    def name(self):
+        name_parts = [self._prefix, self.topic, self._suffix]
+        return '-'.join(filter(lambda x: x, name_parts))
+
+    @property
+    def prefix(self):
+        return self._prefix
+
+    def set_prefix(self, prefix):
+        self._prefix = prefix
+
+    def set_suffix(self, suffix):
+        self._suffix = suffix
 
     def __call__(self, data, **kwargs):
         self._func(data, **kwargs)
@@ -82,7 +92,7 @@ class Callback:
         return result
 
 
-def sub(topic, suffix=None):
+def sub(topic, prefix=None, suffix=None):
     """Decorator function that makes declaring a PubSub Subscription simple.
 
     The Subscriber returned will automatically create and name
@@ -109,13 +119,15 @@ def sub(topic, suffix=None):
              pass
 
     :param topic: string The topic that is being subscribed to.
-    :param suffix: string An options suffix to the subscription name.
+    :param prefix: string An optional prefix to the subscription name.
+                   Useful to namespace your subscription with your project name.
+    :param suffix: string An optional suffix to the subscription name.
                    Useful when you have two subscribers in the same project that
                    are subscribed to the same topic.
     :return: Subscription
     """
 
     def decorator(func):
-        return Subscription(func=func, topic=topic, suffix=suffix)
+        return Subscription(func=func, topic=topic, prefix=prefix, suffix=suffix)
 
     return decorator

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -9,11 +9,11 @@ logger = logging.getLogger(__name__)
 
 class Subscription:
 
-    def __init__(self, func, topic, prefix=None, suffix=None):
+    def __init__(self, func, topic, prefix='', suffix=''):
         self._func = func
         self.topic = topic
-        self._prefix = prefix or ''
-        self._suffix = suffix or ''
+        self._prefix = prefix
+        self._suffix = suffix
 
     @property
     def name(self):

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -3,18 +3,20 @@ import logging
 import time
 
 from django import db
-from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
 
 class Subscription:
 
-    def __init__(self, func, topic, suffix=None):
+    def __init__(self, func, topic, prefix=None, suffix=None):
         self._func = func
         self.topic = topic
-        self.project_name = settings.BASE_DIR.split("/")[-1]
-        self.name = f'{self.project_name}-{topic}'
+        self.prefix = prefix
+        self.name = ''
+        if self.prefix:
+            self.name = f'{self.prefix}-'
+        self.name += topic
         if suffix:
             self.name += f'-{suffix}'
 
@@ -66,7 +68,7 @@ class Callback:
 
     def _build_data_metrics(self, status, start_processing_time):
         result = {
-            'agent': self._subscription.project_name,
+            'agent': self._subscription.prefix or 'rele',
             'topic': self._subscription.topic,
             'status': status,
             'subscription': self._subscription.name,

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -27,9 +27,6 @@ class Subscription:
     def set_prefix(self, prefix):
         self._prefix = prefix
 
-    def set_suffix(self, suffix):
-        self._suffix = suffix
-
     def __call__(self, data, **kwargs):
         self._func(data, **kwargs)
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -31,6 +31,8 @@ RELE_GC_CREDENTIALS = service_account.Credentials.from_service_account_file(
     f'{BASE_DIR}/tests/dummy-pub-sub-credentials.json'
 )
 
+RELE_SUB_PREFIX = 'rele'
+
 logging_config.dictConfig({
     'version': 1,
     'disable_existing_loggers': False,
@@ -46,3 +48,4 @@ logging_config.dictConfig({
         },
     },
 })
+

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -48,4 +48,3 @@ logging_config.dictConfig({
         },
     },
 })
-

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -9,7 +9,7 @@ from rele import Callback, Subscription, sub
 logger = logging.getLogger(__name__)
 
 
-@sub(topic='some-cool-topic')
+@sub(topic='some-cool-topic', prefix='rele')
 def sub_stub(data, **kwargs):
     logger.info(f'I am a task doing stuff with ID {data["id"]} '
                 f'({kwargs["lang"]})')
@@ -104,7 +104,7 @@ class TestCallback:
 
     def test_log_does_not_ack_called_message_when_execution_fails(
             self, caplog, message_wrapper):
-        @sub(topic='some-cool-topic')
+        @sub(topic='some-cool-topic', prefix='rele')
         def crashy_sub_stub(data, **kwargs):
             raise ValueError('I am an exception from a sub')
 

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -15,12 +15,23 @@ def sub_stub(data, **kwargs):
                 f'({kwargs["lang"]})')
 
 
+@sub(topic='some-fancy-topic')
+def sub_fancy_stub(data, **kwargs):
+    logger.info(f'I used to have a prefix, but not anymore, only {data["id"]}'
+                f'id {kwargs["lang"]}')
+
+
 class TestSubscription:
 
     def test_subs_return_subscription_objects(self):
         assert isinstance(sub_stub, Subscription)
         assert sub_stub.topic == 'some-cool-topic'
         assert sub_stub.name == 'rele-some-cool-topic'
+
+    def test_subs_without_prefix_return_subscription_objects(self):
+        assert isinstance(sub_fancy_stub, Subscription)
+        assert sub_fancy_stub.topic == 'some-fancy-topic'
+        assert sub_fancy_stub.name == 'some-fancy-topic'
 
     def test_executes_callback_when_called(self, caplog):
         res = sub_stub({'id': 123}, **{'lang': 'es'})

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7,7 +7,7 @@ from rele import Subscriber, Worker, sub
 from . import settings
 
 
-@sub(topic='some-cool-topic')
+@sub(topic='some-cool-topic', prefix='rele')
 def sub_stub(data, **kwargs):
     print(f'I am a task doing stuff.')
 


### PR DESCRIPTION
### :tophat: What?

Use custom value as prefix to any subscription instead of static project name.

### :thinking: Why?

Small iteration in order to remove completely Django settings usage.
