### PR TITLE
Parametrize subscription ack deadline

### DIFF
--- a/rele/client.py
+++ b/rele/client.py
@@ -24,7 +24,12 @@ class Subscriber:
         else:
             self._client = pubsub_v1.SubscriberClient(credentials=credentials)
 
-    def create_subscription(self, subscription, topic, ack_deadline_seconds=DEFAULT_ACK_DEADLINE):
+    def get_default_ack_deadline(self):
+        return int(os.environ.get('DEFAULT_ACK_DEADLINE', self.DEFAULT_ACK_DEADLINE))
+
+    def create_subscription(self, subscription, topic, ack_deadline_seconds=None):
+        ack_deadline_seconds = ack_deadline_seconds or self.get_default_ack_deadline()
+
         subscription_path = self._client.subscription_path(
             self._gc_project_id, subscription)
         topic_path = self._client.topic_path(self._gc_project_id, topic)

--- a/rele/client.py
+++ b/rele/client.py
@@ -15,6 +15,7 @@ USE_EMULATOR = True if os.environ.get('PUBSUB_EMULATOR_HOST') else False
 
 
 class Subscriber:
+    DEFAULT_ACK_DEADLINE = 60
 
     def __init__(self, gc_project_id, credentials):
         self._gc_project_id = gc_project_id
@@ -23,7 +24,7 @@ class Subscriber:
         else:
             self._client = pubsub_v1.SubscriberClient(credentials=credentials)
 
-    def create_subscription(self, subscription, topic, ack_deadline_seconds=60):
+    def create_subscription(self, subscription, topic, ack_deadline_seconds=DEFAULT_ACK_DEADLINE):
         subscription_path = self._client.subscription_path(
             self._gc_project_id, subscription)
         topic_path = self._client.topic_path(self._gc_project_id, topic)

--- a/rele/client.py
+++ b/rele/client.py
@@ -23,14 +23,16 @@ class Subscriber:
         else:
             self._client = pubsub_v1.SubscriberClient(credentials=credentials)
 
-    def create_subscription(self, subscription, topic):
+    def create_subscription(self, subscription, topic, ack_deadline_seconds=60):
         subscription_path = self._client.subscription_path(
             self._gc_project_id, subscription)
         topic_path = self._client.topic_path(self._gc_project_id, topic)
 
         with suppress(exceptions.AlreadyExists):
             self._client.create_subscription(
-                name=subscription_path, topic=topic_path)
+                name=subscription_path,
+                topic=topic_path,
+                ack_deadline_seconds=ack_deadline_seconds)
 
     def consume(self, subscription_name, callback):
         subscription_path = self._client.subscription_path(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,23 @@ import concurrent
 from unittest.mock import MagicMock, patch
 from google.cloud.pubsub_v1 import PublisherClient
 from rele import Publisher
+from rele.client import Subscriber
 from tests import settings
+
+
+@pytest.fixture()
+def project_id():
+    return 'test-project-id'
+
+
+@pytest.fixture()
+def credentials():
+    return 'my-credentials'
+
+
+@pytest.fixture()
+def subscriber(project_id, credentials):
+    return Subscriber(project_id, credentials)
 
 
 @pytest.fixture(scope='class')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,7 @@
-import pytest
 import concurrent
 from unittest.mock import ANY, patch
 
+import pytest
 from google.cloud.pubsub_v1 import SubscriberClient
 
 from rele.client import Subscriber
@@ -57,35 +57,42 @@ class TestPublisher:
 
 
 class TestSubscriber:
-    @patch.object(SubscriberClient, 'create_subscription')
-    def test_create_subscription_without_ack_deadlines(self, _mocked_client):
-        project_id = settings.RELE_GC_PROJECT_ID
+
+    @pytest.fixture()
+    def project_id(self):
+        return settings.RELE_GC_PROJECT_ID
+
+    @pytest.fixture()
+    def subscriber(self, project_id):
         credentials = settings.RELE_GC_CREDENTIALS
 
-        subscriber = Subscriber(project_id, credentials)
+        return Subscriber(project_id, credentials)
 
-        expected_subscription = f'projects/{project_id}/subscriptions/test-topic'
-        expected_topic = f'projects/{project_id}/topics/{project_id}-test-topic'
+    @patch.object(SubscriberClient, 'create_subscription')
+    def test_create_subscription_without_ack_deadlines(
+            self, _mocked_client, project_id, subscriber):
+        expected_subscription = (f'projects/{project_id}/subscriptions/'
+                                 f'test-topic')
+        expected_topic = (f'projects/{project_id}/topics/'
+                          f'{project_id}-test-topic')
 
         subscriber.create_subscription('test-topic',
-                                       f'{settings.RELE_GC_PROJECT_ID}-test-topic')
+                                       f'{project_id}-test-topic')
 
         _mocked_client.assert_called_once_with(ack_deadline_seconds=60,
                                                name=expected_subscription,
                                                topic=expected_topic)
 
     @patch.object(SubscriberClient, 'create_subscription')
-    def test_create_subscription_with_ack_deadlines(self, _mocked_client):
-        project_id = settings.RELE_GC_PROJECT_ID
-        credentials = settings.RELE_GC_CREDENTIALS
-
-        subscriber = Subscriber(project_id, credentials)
-
-        expected_subscription = f'projects/{project_id}/subscriptions/test-topic'
-        expected_topic = f'projects/{project_id}/topics/{project_id}-test-topic'
+    def test_create_subscription_with_ack_deadlines(
+            self, _mocked_client, project_id, subscriber):
+        expected_subscription = (f'projects/{project_id}/subscriptions/'
+                                 f'test-topic')
+        expected_topic = (f'projects/{project_id}/topics/'
+                          f'{project_id}-test-topic')
 
         subscriber.create_subscription('test-topic',
-                                       f'{settings.RELE_GC_PROJECT_ID}-test-topic',
+                                       f'{project_id}-test-topic',
                                        ack_deadline_seconds=100)
 
         _mocked_client.assert_called_once_with(ack_deadline_seconds=100,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+import os
 import concurrent
 from unittest.mock import ANY, patch
 
@@ -98,3 +99,26 @@ class TestSubscriber:
         _mocked_client.assert_called_once_with(ack_deadline_seconds=100,
                                                name=expected_subscription,
                                                topic=expected_topic)
+
+    @patch.object(SubscriberClient, 'create_subscription')
+    def test_create_subscription_with_ack_deadlines_from_environment(
+            self, _mocked_client, project_id, subscriber):
+        expected_subscription = (f'projects/{project_id}/subscriptions/'
+                                 f'test-topic')
+        expected_topic = (f'projects/{project_id}/topics/'
+                          f'{project_id}-test-topic')
+
+        with patch.dict(os.environ, {'DEFAULT_ACK_DEADLINE': '200'}):
+            subscriber.create_subscription('test-topic',
+                                           f'{project_id}-test-topic')
+
+        _mocked_client.assert_called_once_with(ack_deadline_seconds=200,
+                                               name=expected_subscription,
+                                               topic=expected_topic)
+
+    def test_get_default_ack_deadline(self, subscriber):
+        assert subscriber.get_default_ack_deadline() == 60
+
+    def test_get_default_ack_deadline_from_evironment_variable(self, subscriber):
+        with patch.dict(os.environ, {'DEFAULT_ACK_DEADLINE': '200'}):
+            assert subscriber.get_default_ack_deadline() == 200

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,10 +5,6 @@ from unittest.mock import ANY, patch
 import pytest
 from google.cloud.pubsub_v1 import SubscriberClient
 
-from rele.client import Subscriber
-
-from . import settings
-
 
 @pytest.mark.usefixtures('publisher', 'time_mock')
 class TestPublisher:
@@ -58,17 +54,6 @@ class TestPublisher:
 
 
 class TestSubscriber:
-
-    @pytest.fixture()
-    def project_id(self):
-        return settings.RELE_GC_PROJECT_ID
-
-    @pytest.fixture()
-    def subscriber(self, project_id):
-        credentials = settings.RELE_GC_CREDENTIALS
-
-        return Subscriber(project_id, credentials)
-
     @patch.object(SubscriberClient, 'create_subscription')
     def test_creates_subscription_with_default_ack_deadline_when_none_provided(
             self, _mocked_client, project_id, subscriber):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,12 @@
 import pytest
 import concurrent
-from unittest.mock import ANY
+from unittest.mock import ANY, patch
+
+from google.cloud.pubsub_v1 import SubscriberClient
+
+from rele.client import Subscriber
+
+from . import settings
 
 
 @pytest.mark.usefixtures('publisher', 'time_mock')
@@ -48,3 +54,40 @@ class TestPublisher:
 
         publisher._client.publish.assert_called_with(
             ANY, b'{"foo": "bar"}', published_at=str(published_at))
+
+
+class TestSubscriber:
+    @patch.object(SubscriberClient, 'create_subscription')
+    def test_create_subscription_without_ack_deadlines(self, _mocked_client):
+        project_id = settings.RELE_GC_PROJECT_ID
+        credentials = settings.RELE_GC_CREDENTIALS
+
+        subscriber = Subscriber(project_id, credentials)
+
+        expected_subscription = f'projects/{project_id}/subscriptions/test-topic'
+        expected_topic = f'projects/{project_id}/topics/{project_id}-test-topic'
+
+        subscriber.create_subscription('test-topic',
+                                       f'{settings.RELE_GC_PROJECT_ID}-test-topic')
+
+        _mocked_client.assert_called_once_with(ack_deadline_seconds=60,
+                                               name=expected_subscription,
+                                               topic=expected_topic)
+
+    @patch.object(SubscriberClient, 'create_subscription')
+    def test_create_subscription_with_ack_deadlines(self, _mocked_client):
+        project_id = settings.RELE_GC_PROJECT_ID
+        credentials = settings.RELE_GC_CREDENTIALS
+
+        subscriber = Subscriber(project_id, credentials)
+
+        expected_subscription = f'projects/{project_id}/subscriptions/test-topic'
+        expected_topic = f'projects/{project_id}/topics/{project_id}-test-topic'
+
+        subscriber.create_subscription('test-topic',
+                                       f'{settings.RELE_GC_PROJECT_ID}-test-topic',
+                                       ack_deadline_seconds=100)
+
+        _mocked_client.assert_called_once_with(ack_deadline_seconds=100,
+                                               name=expected_subscription,
+                                               topic=expected_topic)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -70,7 +70,7 @@ class TestSubscriber:
         return Subscriber(project_id, credentials)
 
     @patch.object(SubscriberClient, 'create_subscription')
-    def test_create_subscription_without_ack_deadlines(
+    def test_creates_subscription_with_default_ack_deadline_when_none_provided(
             self, _mocked_client, project_id, subscriber):
         expected_subscription = (f'projects/{project_id}/subscriptions/'
                                  f'test-topic')
@@ -85,7 +85,7 @@ class TestSubscriber:
                                                topic=expected_topic)
 
     @patch.object(SubscriberClient, 'create_subscription')
-    def test_create_subscription_with_ack_deadlines(
+    def test_creates_subscription_with_custom_ack_deadline_when_provided(
             self, _mocked_client, project_id, subscriber):
         expected_subscription = (f'projects/{project_id}/subscriptions/'
                                  f'test-topic')
@@ -101,7 +101,7 @@ class TestSubscriber:
                                                topic=expected_topic)
 
     @patch.object(SubscriberClient, 'create_subscription')
-    def test_create_subscription_with_ack_deadlines_from_environment(
+    def test_creates_subscription_with_custom_ack_deadline_from_environment(
             self, _mocked_client, project_id, subscriber):
         expected_subscription = (f'projects/{project_id}/subscriptions/'
                                  f'test-topic')
@@ -119,7 +119,7 @@ class TestSubscriber:
     def test_get_default_ack_deadline(self, subscriber):
         assert subscriber.get_default_ack_deadline() == 60
 
-    def test_get_default_ack_deadline_from_evironment_variable(
+    def test_get_default_ack_deadline_from_environment_variable(
             self, subscriber):
         with patch.dict(os.environ, {'DEFAULT_ACK_DEADLINE': '200'}):
             assert subscriber.get_default_ack_deadline() == 200

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -119,6 +119,7 @@ class TestSubscriber:
     def test_get_default_ack_deadline(self, subscriber):
         assert subscriber.get_default_ack_deadline() == 60
 
-    def test_get_default_ack_deadline_from_evironment_variable(self, subscriber):
+    def test_get_default_ack_deadline_from_evironment_variable(
+            self, subscriber):
         with patch.dict(os.environ, {'DEFAULT_ACK_DEADLINE': '200'}):
             assert subscriber.get_default_ack_deadline() == 200


### PR DESCRIPTION
### :tophat: What?

Add `DEFAULT_ACK_DEADLINE` variable to configure the default ack deadline (thus, overriding the default value set by Google). Plus, the `create_subscription` method in `Subscriber` class also accepts a custom ack deadline value.

### :thinking: Why?

The default value of 10 seconds set by Google may not be suitable in most of our use cases. Closes #44.
