### PR TITLE
Pass the app_name to the publisher

### DIFF
--- a/rele/client.py
+++ b/rele/client.py
@@ -3,7 +3,6 @@ import logging
 import os
 from contextlib import suppress
 
-from django.conf import settings
 from google.api_core import exceptions
 from google.cloud import pubsub_v1
 from rest_framework.utils import encoders
@@ -39,9 +38,10 @@ class Subscriber:
 
 class Publisher:
 
-    def __init__(self, gc_project_id, credentials, timeout=3.0):
+    def __init__(self, gc_project_id, credentials, app_name, timeout=3.0):
         self._gc_project_id = gc_project_id
         self._timeout = timeout
+        self._app_name = app_name
         if USE_EMULATOR:
             self._client = pubsub_v1.PublisherClient()
         else:
@@ -66,7 +66,7 @@ class Publisher:
         return {
             'name': 'publications',
             'data': {
-                'agent': settings.BASE_DIR.split('/')[-1],
+                'agent': self._app_name,
                 'topic': topic,
             }
         }

--- a/rele/publishing.py
+++ b/rele/publishing.py
@@ -3,10 +3,14 @@ from .client import Publisher
 _publisher = None
 
 
-def init_global_publisher(gc_project_id, credentials):
+def init_global_publisher(gc_project_id, credentials, app_name='rele'):
     global _publisher
     if not _publisher:
-        _publisher = Publisher(gc_project_id, credentials)
+        _publisher = Publisher(
+            gc_project_id=gc_project_id,
+            credentials=credentials,
+            app_name=app_name
+        )
     return _publisher
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,8 @@ class TestPublisher:
     def test_returns_future_when_published_called(self):
         message = {'foo': 'bar'}
         publisher = Publisher(settings.RELE_GC_PROJECT_ID,
-                              settings.RELE_GC_CREDENTIALS)
+                              settings.RELE_GC_CREDENTIALS,
+                              'rele')
         publisher._client = MagicMock(spec=PublisherClient)
         publisher._client.publish.return_value = concurrent.futures.Future()
 
@@ -27,7 +28,7 @@ class TestPublisher:
 
     def test_save_log_when_published_called(self, caplog):
         message = {'foo': 'bar'}
-        publisher = Publisher(1, settings.RELE_GC_CREDENTIALS)
+        publisher = Publisher(1, settings.RELE_GC_CREDENTIALS, 'custom_rele')
         publisher._client = MagicMock(spec=PublisherClient)
         publisher._client.publish.return_value = concurrent.futures.Future()
 
@@ -40,7 +41,7 @@ class TestPublisher:
         assert log.metrics == {
             'name': 'publications',
             'data': {
-                'agent': 'rele',
+                'agent': 'custom_rele',
                 'topic': 'order-cancelled',
             }
         }


### PR DESCRIPTION
### :tophat: What?

Passing `app_name` to the publisher

### :thinking: Why?

So we can remove the use of `django.conf.settings` in the client module. 
