### PR TITLE
Update contributing.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,7 @@ Provide a description of what has been implemented.
 ### :thinking: Why?
 
 Give an explanation of why.
+
+### :eslabón: Related issue
+
+Add related issue's number. Example: Fix #1

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,6 @@ Provide a description of what has been implemented.
 
 Give an explanation of why.
 
-### :eslabón: Related issue
+### :link: Related issue
 
 Add related issue's number. Example: Fix #1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ It is always best to have community input before proposing changes that may late
 * Run `make lint` on any modified files.
 * If your branch is behind master, 
 [rebase](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request) on top of it.
-* Include the related issue's number so that Github closes _automagically: when the PR is merged.
+* Include the related issue's number so that Github closes _automagically_ when the PR is merged. Example: `Fix #12`
 
 ## Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ It is always best to have community input before proposing changes that may late
 * Run `make lint` on any modified files.
 * If your branch is behind master, 
 [rebase](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request) on top of it.
+* Include the related issue's number so that Github closes _automagically: when the PR is merged.
 
 ## Issues
 


### PR DESCRIPTION
### :tophat: What?

Add contributing guideline to bind issue and pr.

Fix #51 

### :thinking: Why?

Issue remained open after related PR was merged.
Github has a mechanism to close the primer when the latter is merged.
