### PR TITLE
Increase Codecov from 54% to 83%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ clean-pyc: ## remove Python file artifacts
 	find . -name '*~' -exec rm -f {} +
 
 lint: ## check style with flake8
-	flake8 pubsub tests
+	flake8 rele tests
 
 test: ## run tests quickly with the default Python
 	python runtests.py tests

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ clean-pyc: ## remove Python file artifacts
 	find . -name '*~' -exec rm -f {} +
 
 lint: ## check style with flake8
-	flake8 rele tests
+	flake8 pubsub tests
 
 test: ## run tests quickly with the default Python
 	python runtests.py tests

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test: ## run tests quickly with the default Python
 	python runtests.py tests
 
 coverage: ## generates codecov report
-	python runtests.py tests --cov=rele
+	coverage run --source rele runtests.py tests
 
 release: clean install-deploy-requirements sdist ## package and upload a release
 	twine upload -u mercadonatech dist/*

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 <p align="center">
-<img src="docs/_static/rele_logo.png" align="center" height="200">
+    <img src="docs/_static/rele_logo.png" align="center" height="200">
 </p>
 
-[![Build Status](https://travis-ci.org/mercadona/rele.svg?branch=master)](https://travis-ci.org/mercadona/rele)
-[![Documentation Status](https://readthedocs.org/projects/mercadonarele/badge/?version=latest)](https://mercadonarele.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/mercadona/rele/branch/master/graph/badge.svg)](https://codecov.io/gh/mercadona/rele)
+<p align="center">
+    <a href="https://travis-ci.org/mercadona/rele">
+        <img src="https://travis-ci.org/mercadona/rele.svg?branch=master"
+             alt="Build Status">
+    </a>
+    <a href="https://mercadonarele.readthedocs.io/en/latest/?badge=latest">
+        <img src="https://readthedocs.org/projects/mercadonarele/badge/?version=latest"
+             alt="Read the Docs">
+    </a>
+    <a href="https://codecov.io/gh/mercadona/rele">
+        <img src="https://codecov.io/gh/mercadona/rele/branch/master/graph/badge.svg"
+             alt="Code Coverage">
+    </a>
+</p>
 
 Relé makes integration with Google PubSub easier and is ready to integrate seamlessly into any Django project.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 </p>
 
 <p align="center">
+    Relé makes integration with Google PubSub easier and is ready to integrate seamlessly into any Django project.
+</p>
+
+<p align="center">
     <a href="https://travis-ci.org/mercadona/rele">
         <img src="https://travis-ci.org/mercadona/rele.svg?branch=master"
              alt="Build Status">
@@ -17,7 +21,6 @@
     </a>
 </p>
 
-Relé makes integration with Google PubSub easier and is ready to integrate seamlessly into any Django project.
 
 ## Motivation and Features
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Build Status](https://travis-ci.org/mercadona/rele.svg?branch=master)](https://travis-ci.org/mercadona/rele)
 [![Documentation Status](https://readthedocs.org/projects/mercadonarele/badge/?version=latest)](https://mercadonarele.readthedocs.io/en/latest/?badge=latest)
+[![codecov](https://codecov.io/gh/mercadona/rele/branch/master/graph/badge.svg)](https://codecov.io/gh/mercadona/rele)
 
 Relé makes integration with Google PubSub easier and is ready to integrate seamlessly into any Django project.
 


### PR DESCRIPTION
### :tophat: What?

Use coverage to run tests for codecov. 
Add the codecov badge in the readme.

### :thinking: Why?

This increases our codecov from 58% to ~80%. The previous implementation used pytest directly which skewed the results of the coverage report. For instance, [it did not mark our import statements in the modules as covered](https://codecov.io/gh/mercadona/rele/src/modify-ack-deadline/rele/client.py#L2), even though they were. 

It'll be a reminder that we need to increase the coverage.

### :link: Related issue

#46 
