### PR TITLE
Move all documentation modules templates from docs to docs/modules

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,18 +42,10 @@ _______
 .. toctree::
     :maxdepth: 2
 
-    subscription
+    modules/subscription
     modules/client
-
-.. toctree::
-   :maxdepth: 2
-
-   publish
-
-.. toctree::
-   :maxdepth: 2
-
-   worker
+    modules/publish
+    modules/worker
 
 Indices and tables
 ==================

--- a/docs/modules/publish.rst
+++ b/docs/modules/publish.rst
@@ -1,10 +1,10 @@
-.. _worker
+.. _ publish
 
-Worker
+Publish
 =======
 
 .. automodule:: rele
    :members:
 
-.. automodule:: rele.worker
+.. automodule:: rele.publishing
    :members:

--- a/docs/modules/subscription.rst
+++ b/docs/modules/subscription.rst
@@ -1,7 +1,8 @@
-.. _subscription
+.. _ subscription
 
 Subscription
 ============
+
 
 .. automodule:: rele
    :members:

--- a/docs/modules/worker.rst
+++ b/docs/modules/worker.rst
@@ -1,10 +1,10 @@
-.. _publish
+.. _ worker
 
-Publish
+Worker
 =======
 
 .. automodule:: rele
    :members:
 
-.. automodule:: rele.publishing
+.. automodule:: rele.worker
    :members:


### PR DESCRIPTION
### :tophat: What?

I've created a modules directory inside the docs folder for a better structure of our documentation.
Now client, publish, subscription and worker template are inside docs/modules.

### :thinking: Why?

As we start to increase or documentation it can be hard to find files. If we split them into directories is much easier to find and organise them. 
