### PR TITLE
Decouple django settings

### DIFF
--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,6 +1,7 @@
 __version__ = '0.3.1'
 
 from .client import Publisher, Subscriber  # noqa
+from .config import setup  # noqa
 from .publishing import publish  # noqa
 from .subscription import Callback, Subscription, sub  # noqa
 from .worker import Worker  # noqa

--- a/rele/apps.py
+++ b/rele/apps.py
@@ -1,5 +1,11 @@
 from django.apps import AppConfig
+from django.conf import settings
+
+import rele.config
 
 
 class ReleConfig(AppConfig):
     name = 'rele'
+
+    def ready(self):
+        rele.config.setup(settings.RELE)

--- a/rele/config.py
+++ b/rele/config.py
@@ -2,9 +2,9 @@ from .middleware import register_middleware
 from .publishing import init_global_publisher
 
 
-def setup(config):
-    gc_project_id = config.get('GC_PROJECT_ID')
-    credentials = config.get('GC_CREDENTIALS')
+def setup(setting):
+    gc_project_id = setting.get('GC_PROJECT_ID')
+    credentials = setting.get('GC_CREDENTIALS')
 
     init_global_publisher(gc_project_id, credentials)
-    register_middleware(config)
+    register_middleware(setting)

--- a/rele/config.py
+++ b/rele/config.py
@@ -1,3 +1,6 @@
+import importlib
+
+from rele.subscription import Subscription
 from .middleware import register_middleware, default_middleware
 from .publishing import init_global_publisher
 
@@ -17,3 +20,16 @@ def setup(setting):
     init_global_publisher(config)
     register_middleware(config)
     return config
+
+
+def load_subscriptions_from_paths(sub_module_paths, sub_prefix=None):
+    subscriptions = []
+    for sub_module_path in sub_module_paths:
+        sub_module = importlib.import_module(sub_module_path)
+        for attr_name in dir(sub_module):
+            attribute = getattr(sub_module, attr_name)
+            if isinstance(attribute, Subscription):
+                if sub_prefix and not attribute.prefix:
+                    attribute.set_prefix(sub_prefix)
+                subscriptions.append(attribute)
+    return subscriptions

--- a/rele/config.py
+++ b/rele/config.py
@@ -2,9 +2,18 @@ from .middleware import register_middleware
 from .publishing import init_global_publisher
 
 
-def setup(setting):
-    gc_project_id = setting.get('GC_PROJECT_ID')
-    credentials = setting.get('GC_CREDENTIALS')
+class Config:
 
-    init_global_publisher(gc_project_id, credentials)
-    register_middleware(setting)
+    def __init__(self, setting):
+        self.gc_project_id = setting.get('GC_PROJECT_ID')
+        self.credentials = setting.get('GC_CREDENTIALS')
+        self.app_name = setting.get('APP_NAME')
+        self.sub_prefix = setting.get('SUB_PREFIX')
+        self.middleware = setting.get('MIDDLEWARE')
+
+
+def setup(setting):
+    conf = Config(setting)
+    init_global_publisher(conf.gc_project_id, conf.credentials)
+    register_middleware(conf)
+    return conf

--- a/rele/config.py
+++ b/rele/config.py
@@ -2,6 +2,9 @@ from .middleware import register_middleware
 from .publishing import init_global_publisher
 
 
-def setup(gc_project_id, credentials, middleware_paths):
+def setup(config):
+    gc_project_id = config.get('GC_PROJECT_ID')
+    credentials = config.get('GC_CREDENTIALS')
+
     init_global_publisher(gc_project_id, credentials)
-    register_middleware(middleware_paths)
+    register_middleware(config)

--- a/rele/config.py
+++ b/rele/config.py
@@ -13,7 +13,7 @@ class Config:
 
 
 def setup(setting):
-    conf = Config(setting)
-    init_global_publisher(conf.gc_project_id, conf.credentials)
-    register_middleware(conf)
-    return conf
+    config = Config(setting)
+    init_global_publisher(config)
+    register_middleware(config)
+    return config

--- a/rele/config.py
+++ b/rele/config.py
@@ -1,4 +1,4 @@
-from .middleware import register_middleware
+from .middleware import register_middleware, default_middleware
 from .publishing import init_global_publisher
 
 
@@ -9,7 +9,7 @@ class Config:
         self.credentials = setting.get('GC_CREDENTIALS')
         self.app_name = setting.get('APP_NAME')
         self.sub_prefix = setting.get('SUB_PREFIX')
-        self.middleware = setting.get('MIDDLEWARE')
+        self.middleware = setting.get('MIDDLEWARE', default_middleware)
 
 
 def setup(setting):

--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -8,9 +8,9 @@ from rele.middleware import BaseMiddleware
 
 class LoggingMiddleware(BaseMiddleware):
 
-    def __init__(self):
+    def __init__(self, config):
         self._logger = None
-        self._app_name = settings.BASE_DIR.split('/')[-1]
+        self._app_name = config.get('APP_NAME')
 
     def setup(self):
         self._logger = logging.getLogger(__name__)

--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -1,19 +1,17 @@
 import logging
 import time
 
-from django.conf import settings
-
 from rele.middleware import BaseMiddleware
 
 
 class LoggingMiddleware(BaseMiddleware):
 
-    def __init__(self, config):
+    def __init__(self):
         self._logger = None
-        self._app_name = config.get('APP_NAME')
 
-    def setup(self):
+    def setup(self, config):
         self._logger = logging.getLogger(__name__)
+        self._app_name = config.get('APP_NAME')
 
     def _build_data_metrics(self, subscription, status, start_processing_time=None):
         result = {

--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -11,7 +11,7 @@ class LoggingMiddleware(BaseMiddleware):
 
     def setup(self, config):
         self._logger = logging.getLogger(__name__)
-        self._app_name = config.get('APP_NAME')
+        self._app_name = config.app_name
 
     def _build_data_metrics(self, subscription, status, start_processing_time=None):
         result = {

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     help = 'Start subscriber threads to consume rele topics.'
 
     def handle(self, *args, **options):
-        config.setup(config=settings.RELE)
+        config.setup(setting=settings.RELE)
         sub_prefix = settings.RELE.get('SUB_PREFIX')
         subs = self._autodiscover_subs(sub_prefix)
         self.stdout.write(f'Configuring worker with {len(subs)} '

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -17,14 +17,13 @@ class Command(BaseCommand):
     help = 'Start subscriber threads to consume rele topics.'
 
     def handle(self, *args, **options):
-        config.setup(setting=settings.RELE)
-        sub_prefix = settings.RELE.get('SUB_PREFIX')
-        subs = self._autodiscover_subs(sub_prefix)
+        conf = config.setup(setting=settings.RELE)
+        subs = self._autodiscover_subs(conf.sub_prefix)
         self.stdout.write(f'Configuring worker with {len(subs)} '
                           f'subscription(s)...')
         for sub in subs:
             self.stdout.write(f'  {sub}')
-        worker = Worker(subs, config=settings.RELE)
+        worker = Worker(subs, config=conf)
         worker.setup()
         worker.start()
 

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -17,13 +17,13 @@ class Command(BaseCommand):
     help = 'Start subscriber threads to consume rele topics.'
 
     def handle(self, *args, **options):
-        conf = config.setup(setting=settings.RELE)
-        subs = self._autodiscover_subs(conf.sub_prefix)
+        rele_config = config.setup(setting=settings.RELE)
+        subs = self._autodiscover_subs(rele_config.sub_prefix)
         self.stdout.write(f'Configuring worker with {len(subs)} '
                           f'subscription(s)...')
         for sub in subs:
             self.stdout.write(f'  {sub}')
-        worker = Worker(subs, config=conf)
+        worker = Worker(subs, config=rele_config)
         worker.setup()
         worker.start()
 

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -3,6 +3,9 @@ import importlib
 _middlewares = []
 
 
+default_middleware = ['rele.contrib.LoggingMiddleware']
+
+
 def register_middleware(config):
     paths = config.middleware
     global _middlewares

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -4,7 +4,7 @@ _middlewares = []
 
 
 def register_middleware(config):
-    paths = config.get('MIDDLEWARE')
+    paths = config.middleware
     global _middlewares
     _middlewares = []
     for path in paths:

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -3,7 +3,8 @@ import importlib
 _middlewares = []
 
 
-def register_middleware(paths):
+def register_middleware(config):
+    paths = config.get('MIDDLEWARE')
     global _middlewares
     _middlewares = []
     for path in paths:
@@ -11,7 +12,7 @@ def register_middleware(paths):
         module_path = '.'.join(module_parts)
         module = importlib.import_module(module_path)
         middleware = getattr(module, middleware_class)()
-        middleware.setup()
+        middleware.setup(config)
         _middlewares.append(middleware)
 
 
@@ -22,7 +23,7 @@ def run_middleware_hook(hook_name, *args, **kwargs):
 
 class BaseMiddleware:
 
-    def setup(self):
+    def setup(self, config):
         pass
 
     def pre_publish(self, topic, data, attrs):

--- a/rele/publishing.py
+++ b/rele/publishing.py
@@ -3,10 +3,10 @@ from .client import Publisher
 _publisher = None
 
 
-def init_global_publisher(gc_project_id, credentials):
+def init_global_publisher(config):
     global _publisher
     if not _publisher:
-        _publisher = Publisher(gc_project_id, credentials)
+        _publisher = Publisher(config.gc_project_id, config.credentials)
     return _publisher
 
 

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -18,7 +18,7 @@ class Worker:
     """
     def __init__(self, subscriptions, config):
         gc_project_id = config.gc_project_id
-        credentials = config.gc_credentials
+        credentials = config.credentials
 
         self._subscriber = Subscriber(gc_project_id, credentials)
         self._futures = []

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -16,10 +16,7 @@ class Worker:
 
     :param subscriptions: list, List of :class:`rele.subscription.Subscription`
     """
-    def __init__(self, subscriptions, config):
-        gc_project_id = config.gc_project_id
-        credentials = config.credentials
-
+    def __init__(self, subscriptions, gc_project_id, credentials):
         self._subscriber = Subscriber(gc_project_id, credentials)
         self._futures = []
         self._subscriptions = subscriptions

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -16,7 +16,10 @@ class Worker:
 
     :param subscriptions: list, List of :class:`rele.subscription.Subscription`
     """
-    def __init__(self, gc_project_id, credentials, subscriptions):
+    def __init__(self, subscriptions, config):
+        gc_project_id = config.get('GC_PROJECT_ID')
+        credentials = config.get('GC_CREDENTIALS')
+
         self._subscriber = Subscriber(gc_project_id, credentials)
         self._futures = []
         self._subscriptions = subscriptions

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -17,8 +17,8 @@ class Worker:
     :param subscriptions: list, List of :class:`rele.subscription.Subscription`
     """
     def __init__(self, subscriptions, config):
-        gc_project_id = config.get('GC_PROJECT_ID')
-        credentials = config.get('GC_CREDENTIALS')
+        gc_project_id = config.gc_project_id
+        credentials = config.gc_credentials
 
         self._subscriber = Subscriber(gc_project_id, credentials)
         self._futures = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from google.cloud.pubsub_v1 import PublisherClient
 from rele import Publisher
 from rele.client import Subscriber
 from rele.middleware import register_middleware
-from tests import settings
 
 
 @pytest.fixture
@@ -19,14 +18,25 @@ def credentials():
 
 
 @pytest.fixture
+def config(credentials, project_id):
+    return {
+        'APP_NAME': 'rele',
+        'SUB_PREFIX': 'rele',
+        'GC_PROJECT_ID': project_id,
+        'GC_CREDENTIALS': credentials,
+        'MIDDLEWARE': ['rele.contrib.LoggingMiddleware']
+    }
+
+
+@pytest.fixture
 def subscriber(project_id, credentials):
     return Subscriber(project_id, credentials)
 
 
-@pytest.fixture(scope='class')
-def publisher():
-    publisher = Publisher(settings.RELE_GC_PROJECT_ID,
-                          settings.RELE_GC_CREDENTIALS)
+@pytest.fixture
+def publisher(config):
+    publisher = Publisher(config.get('GC_PROJECT_ID'),
+                          config.get('GC_CREDENTIALS'))
     publisher._client = MagicMock(spec=PublisherClient)
     publisher._client.publish.return_value = concurrent.futures.Future()
 
@@ -46,5 +56,5 @@ def time_mock(published_at):
 
 
 @pytest.fixture(autouse=True)
-def default_middleware():
-    register_middleware(['rele.contrib.LoggingMiddleware'])
+def default_middleware(config):
+    register_middleware(config=config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import pytest
 import concurrent
 from unittest.mock import MagicMock, patch
 from google.cloud.pubsub_v1 import PublisherClient
+
+from rele.config import Config
 from rele import Publisher
 from rele.client import Subscriber
 from rele.middleware import register_middleware
@@ -19,13 +21,13 @@ def credentials():
 
 @pytest.fixture
 def config(credentials, project_id):
-    return {
+    return Config({
         'APP_NAME': 'rele',
         'SUB_PREFIX': 'rele',
         'GC_PROJECT_ID': project_id,
         'GC_CREDENTIALS': credentials,
         'MIDDLEWARE': ['rele.contrib.LoggingMiddleware']
-    }
+    })
 
 
 @pytest.fixture
@@ -35,8 +37,8 @@ def subscriber(project_id, credentials):
 
 @pytest.fixture
 def publisher(config):
-    publisher = Publisher(config.get('GC_PROJECT_ID'),
-                          config.get('GC_CREDENTIALS'))
+    publisher = Publisher(config.gc_project_id,
+                          config.credentials)
     publisher._client = MagicMock(spec=PublisherClient)
     publisher._client.publish.return_value = concurrent.futures.Future()
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -26,7 +26,7 @@ MIDDLEWARE_CLASSES = ()
 
 RELE = {
     'APP_NAME': 'test-rele',
-    'PROJECT_ID': 'SOME-PROJECT-ID',
+    'GC_PROJECT_ID': 'SOME-PROJECT-ID',
     'GC_CREDENTIALS': service_account.Credentials.from_service_account_file(
         f'{BASE_DIR}/tests/dummy-pub-sub-credentials.json'
     ),

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -24,17 +24,18 @@ SITE_ID = 1
 
 MIDDLEWARE_CLASSES = ()
 
-# Google Cloud
-RELE_GC_PROJECT_ID = 'SOME-PROJECT-ID'
-RELE_GC_CREDENTIALS = service_account.Credentials.from_service_account_file(
-    f'{BASE_DIR}/tests/dummy-pub-sub-credentials.json'
-)
-RELE_SUB_PREFIX = 'rele'
-
-RELE_MIDDLEWARE = [
-    'rele.contrib.LoggingMiddleware',
-    'rele.contrib.DjangoDBMiddleware',
-]
+RELE = {
+    'APP_NAME': 'test-rele',
+    'PROJECT_ID': 'SOME-PROJECT-ID',
+    'GC_CREDENTIALS': service_account.Credentials.from_service_account_file(
+        f'{BASE_DIR}/tests/dummy-pub-sub-credentials.json'
+    ),
+    'SUB_PREFIX': 'rele',
+    'MIDDLEWARE': [
+        'rele.contrib.LoggingMiddleware',
+        'rele.contrib.DjangoDBMiddleware',
+    ],
+}
 
 logging_config.dictConfig({
     'version': 1,

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -2,17 +2,14 @@ from unittest.mock import MagicMock, patch
 
 from rele import Publisher, publishing
 
-from . import settings
-
 
 class TestPublish:
 
     @patch('rele.publishing.Publisher', autospec=True)
     def test_creates_global_publisher_when_published_called(
-            self, mock_publisher):
+            self, mock_publisher, project_id, credentials):
         mock_publisher.return_value = MagicMock(spec=Publisher)
-        publishing.init_global_publisher(settings.RELE_GC_PROJECT_ID,
-                                         settings.RELE_GC_CREDENTIALS)
+        publishing.init_global_publisher(project_id, credentials)
         message = {'foo': 'bar'}
         publishing.publish(
             topic='order-cancelled', data=message, myattr='hello')

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -7,9 +7,9 @@ class TestPublish:
 
     @patch('rele.publishing.Publisher', autospec=True)
     def test_creates_global_publisher_when_published_called(
-            self, mock_publisher, project_id, credentials):
+            self, mock_publisher, config):
         mock_publisher.return_value = MagicMock(spec=Publisher)
-        publishing.init_global_publisher(project_id, credentials)
+        publishing.init_global_publisher(config)
         message = {'foo': 'bar'}
         publishing.publish(
             topic='order-cancelled', data=message, myattr='hello')

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -160,8 +160,9 @@ class TestCallback:
         assert success_log.message == "<class 'float'>"
 
     def test_old_django_connections_closed_when_middleware_is_used(
-            self, mock_close_old_connections, message_wrapper):
-        register_middleware(['rele.contrib.DjangoDBMiddleware'])
+            self, mock_close_old_connections, message_wrapper, config):
+        config['MIDDLEWARE'] = ['rele.contrib.DjangoDBMiddleware']
+        register_middleware(config)
         callback = Callback(sub_stub)
         res = callback(message_wrapper)
 

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -161,7 +161,7 @@ class TestCallback:
 
     def test_old_django_connections_closed_when_middleware_is_used(
             self, mock_close_old_connections, message_wrapper, config):
-        config['MIDDLEWARE'] = ['rele.contrib.DjangoDBMiddleware']
+        config.middleware = ['rele.contrib.DjangoDBMiddleware']
         register_middleware(config)
         callback = Callback(sub_stub)
         res = callback(message_wrapper)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -38,7 +38,7 @@ class TestWorker:
 
     @patch('rele.contrib.django_db_middleware.db.connections.close_all')
     def test_stop_closes_db_connections(self, mock_db_close_all, config):
-        config['MIDDLEWARE'] = ['rele.contrib.DjangoDBMiddleware']
+        config.middleware = ['rele.contrib.DjangoDBMiddleware']
         register_middleware(config=config)
         subscriptions = (sub_stub,)
         worker = Worker(subscriptions, config=config)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -15,9 +15,9 @@ class TestWorker:
 
     @patch.object(Subscriber, 'consume')
     def test_start_subscribes_and_saves_futures_when_subscriptions_given(
-            self, mock_consume, config):
+            self, mock_consume, project_id, credentials):
         subscriptions = (sub_stub,)
-        worker = Worker(subscriptions, config=config)
+        worker = Worker(subscriptions, project_id, credentials)
         worker.start()
 
         mock_consume.assert_called_once_with(
@@ -27,9 +27,9 @@ class TestWorker:
 
     @patch.object(Subscriber, 'create_subscription')
     def test_setup_creates_subscription_when_topic_given(
-            self, mock_create_subscription, config):
+            self, mock_create_subscription, project_id, credentials):
         subscriptions = (sub_stub,)
-        worker = Worker(subscriptions, config=config)
+        worker = Worker(subscriptions, project_id, credentials)
         worker.setup()
 
         topic = 'some-cool-topic'
@@ -37,11 +37,12 @@ class TestWorker:
         mock_create_subscription.assert_called_once_with(subscription, topic)
 
     @patch('rele.contrib.django_db_middleware.db.connections.close_all')
-    def test_stop_closes_db_connections(self, mock_db_close_all, config):
+    def test_stop_closes_db_connections(
+            self, mock_db_close_all, config,  project_id, credentials):
         config.middleware = ['rele.contrib.DjangoDBMiddleware']
         register_middleware(config=config)
         subscriptions = (sub_stub,)
-        worker = Worker(subscriptions, config=config)
+        worker = Worker(subscriptions, project_id, credentials)
 
         with pytest.raises(SystemExit):
             worker.stop()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -38,7 +38,7 @@ class TestWorker:
 
     @patch('rele.contrib.django_db_middleware.db.connections.close_all')
     def test_stop_closes_db_connections(
-            self, mock_db_close_all, config,  project_id, credentials):
+            self, mock_db_close_all, config, project_id, credentials):
         config.middleware = ['rele.contrib.DjangoDBMiddleware']
         register_middleware(config=config)
         subscriptions = (sub_stub,)


### PR DESCRIPTION
### :tophat: What?

Move config to an Object. 
Call rele.setup in apps.py

### :thinking: Why?

Moves dependency of django.conf.settings away from the Middleware and makes config more agnostic, less django dependent.

### :link: Related issue

Addresses #38 
