### PR TITLE
Register contrib package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     url='https://github.com/mercadona/rele',
     packages=[
         'rele',
+        'rele.contrib',
         'rele.management',
         'rele.management.commands',
     ],


### PR DESCRIPTION
### :tophat: What?

Register `rele.contrib` package in `setup.py`.

### :thinking: Why?

This way the package gets shipped with the library.
