### PR TITLE
Use find_packages in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 </p>
 
 <p align="center">
-    Relé makes integration with Google PubSub easier and is ready to integrate seamlessly into any Django project.
+    <strong>
+        Relé makes integration with Google PubSub easier and is ready to 
+        integrate seamlessly into any Django project.
+    </strong>
 </p>
 
 <p align="center">

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,7 @@ import os
 import re
 import sys
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup, find_packages
 
 
 def get_version(*file_paths):
@@ -35,18 +32,13 @@ readme = open('README.md').read()
 setup(
     name='rele',
     version=version,
-    description="""Google PubSub for Django""",
+    description="""Relé makes integration with Google PubSub easier.""",
     long_description=readme,
     long_description_content_type='text/markdown',
     author='MercadonaTech',
     author_email='software.online@mercadona.es',
     url='https://github.com/mercadona/rele',
-    packages=[
-        'rele',
-        'rele.contrib',
-        'rele.management',
-        'rele.management.commands',
-    ],
+    packages=find_packages(exclude=("tests",)),
     include_package_data=True,
     install_requires=['django', 'djangorestframework', 'google-cloud-pubsub'],
     license='Apache Software License 2.0',


### PR DESCRIPTION
### :tophat: What?

Use `find_packages` from setup tools

```
>>> find_packages(exclude=("tests",))
['rele', 'rele.management', 'rele.contrib', 'rele.management.commands']
```

### :thinking: Why?

To avoid #61 

### :link: Related issue

Fixes the issue discovered in #61 
