### PR TITLE
Filter by message attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,6 @@ install-docs-requirements:  ## install requirements for documentation
 
 install-dev-requirements: install-requirements install-test-requirements install-docs-requirements
 
-build-html-doc:
+build-html-doc: ## builds the project documentation in HTML format
 	DJANGO_SETTINGS_MODULE=tests.settings make html -C docs
 	open docs/_build/html/index.html

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -11,11 +11,12 @@ class Subscription:
     """The Subscription class
 
     """
-    def __init__(self, func, topic, prefix='', suffix=''):
+    def __init__(self, func, topic, prefix='', suffix='', filter_by=None):
         self._func = func
         self.topic = topic
         self._prefix = prefix
         self._suffix = suffix
+        self._filter_by = filter_by
 
     @property
     def name(self):
@@ -33,7 +34,10 @@ class Subscription:
         if 'published_at' in kwargs:
             kwargs['published_at'] = float(kwargs['published_at'])
 
-        return self._func(data, **kwargs)
+        if self._filter_by:
+            self._filter_by(**kwargs)
+
+        self._func(data, **kwargs)
 
     def __str__(self):
         return f'{self.name} - {self._func.__name__}'
@@ -65,7 +69,7 @@ class Callback:
             run_middleware_hook('post_process_message')
 
 
-def sub(topic, prefix=None, suffix=None):
+def sub(topic, prefix=None, suffix=None, filter_by=None):
     """Decorator function that makes declaring a PubSub Subscription simple.
 
     The Subscriber returned will automatically create and name
@@ -106,11 +110,10 @@ def sub(topic, prefix=None, suffix=None):
     """
 
     def decorator(func):
-        return Subscription(
-            func=func,
-            topic=topic,
-            prefix=prefix,
-            suffix=suffix
-        )
+        return Subscription(func=func,
+                            topic=topic,
+                            prefix=prefix,
+                            suffix=suffix,
+                            filter_by=filter_by)
 
     return decorator

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -16,7 +16,7 @@ class Subscription:
         self.topic = topic
         self._prefix = prefix
         self._suffix = suffix
-        self._filter_by = filter_by
+        self._filter_by = filter_by or (lambda **_: True)
 
     @property
     def name(self):
@@ -34,10 +34,8 @@ class Subscription:
         if 'published_at' in kwargs:
             kwargs['published_at'] = float(kwargs['published_at'])
 
-        if self._filter_by:
-            self._filter_by(**kwargs)
-
-        self._func(data, **kwargs)
+        if self._filter_by(**kwargs):
+            self._func(data, **kwargs)
 
     def __str__(self):
         return f'{self.name} - {self._func.__name__}'

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -100,12 +100,19 @@ def sub(topic, prefix=None, suffix=None, filter_by=None):
         def purpose_2(data, **kwargs):
              pass
 
+        @sub(topic='photo-updated',
+             filter_by=lambda **attrs: attrs.get('type') == 'landscape')
+        def sub_process_landscape_photos(data, **kwargs):
+            pass
+
     :param topic: string The topic that is being subscribed to.
     :param prefix: string An optional prefix to the subscription name.
                    Useful to namespace your subscription with your project name
     :param suffix: string An optional suffix to the subscription name.
                    Useful when you have two subscribers in the same project
                    that are subscribed to the same topic.
+    :param filter_by: function An optional function that filters the messages to
+                      be processed by the sub regarding their attributes.
     :return: :class:`~rele.subscription.Subscription`
     """
 

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -111,8 +111,9 @@ def sub(topic, prefix=None, suffix=None, filter_by=None):
     :param suffix: string An optional suffix to the subscription name.
                    Useful when you have two subscribers in the same project
                    that are subscribed to the same topic.
-    :param filter_by: function An optional function that filters the messages to
-                      be processed by the sub regarding their attributes.
+    :param filter_by: function An optional function that
+                      filters the messages to be processed
+                      by the sub regarding their attributes.
     :return: :class:`~rele.subscription.Subscription`
     """
 

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -35,7 +35,9 @@ class Subscription:
             kwargs['published_at'] = float(kwargs['published_at'])
 
         if self._filter_by(**kwargs):
-            self._func(data, **kwargs)
+            return self._func(data, **kwargs)
+
+        return None
 
     def __str__(self):
         return f'{self.name} - {self._func.__name__}'

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -60,14 +60,17 @@ class TestSubscription:
         assert log2.message == 'I am a task doing stuff with ID 123 (es)'
 
     def test_sub_executes_when_message_attributes_match_criteria(self, caplog):
-        sub_process_landscape_photos({'name': 'my_new_photo.jpeg'}, type='landscape')
+        data = {'name': 'my_new_photo.jpeg'}
+        sub_process_landscape_photos(data, type='landscape')
 
         assert len(caplog.records) == 1
         log = caplog.records[0]
         assert log.message == 'Received a photo of type landscape'
 
-    def test_sub_does_not_execute_when_message_attributes_dont_match_criteria(self, caplog):
-        sub_process_landscape_photos({'name': 'my_new_photo.jpeg'}, type='')
+    def test_sub_does_not_execute_when_message_attributes_dont_match_criteria(
+            self, caplog):
+        data = {'name': 'my_new_photo.jpeg'}
+        sub_process_landscape_photos(data, type='')
 
         assert len(caplog.records) == 0
 

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -30,6 +30,16 @@ def sub_published_time_type(data, **kwargs):
     logger.info(f'{type(kwargs["published_at"])}')
 
 
+def landscape_filter(**kwargs):
+    return kwargs.get('type') == 'landscape'
+
+
+@sub(topic='photo-updated', filter_by=landscape_filter)
+def sub_process_landscape_photos(data, **kwargs):
+    photo_type = kwargs.get('type')
+    logger.info(f'Received a photo of type {photo_type}')
+
+
 class TestSubscription:
 
     def test_subs_return_subscription_objects(self):
@@ -48,6 +58,13 @@ class TestSubscription:
         assert res == 123
         log2 = caplog.records[0]
         assert log2.message == 'I am a task doing stuff with ID 123 (es)'
+
+    def test_sub_executes_when_message_attributes_match_criteria(self, caplog):
+        sub_process_landscape_photos({'name': 'my_new_photo.jpeg'}, type='landscape')
+
+        assert len(caplog.records) == 1
+        log = caplog.records[0]
+        assert log.message == 'Received a photo of type landscape'
 
 
 class TestCallback:

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -36,8 +36,7 @@ def landscape_filter(**kwargs):
 
 @sub(topic='photo-updated', filter_by=landscape_filter)
 def sub_process_landscape_photos(data, **kwargs):
-    photo_type = kwargs.get('type')
-    logger.info(f'Received a photo of type {photo_type}')
+    return f'Received a photo of type {kwargs.get("type")}'
 
 
 class TestSubscription:
@@ -61,18 +60,16 @@ class TestSubscription:
 
     def test_sub_executes_when_message_attributes_match_criteria(self, caplog):
         data = {'name': 'my_new_photo.jpeg'}
-        sub_process_landscape_photos(data, type='landscape')
+        response = sub_process_landscape_photos(data, type='landscape')
 
-        assert len(caplog.records) == 1
-        log = caplog.records[0]
-        assert log.message == 'Received a photo of type landscape'
+        assert response == 'Received a photo of type landscape'
 
     def test_sub_does_not_execute_when_message_attributes_dont_match_criteria(
             self, caplog):
         data = {'name': 'my_new_photo.jpeg'}
-        sub_process_landscape_photos(data, type='')
+        response = sub_process_landscape_photos(data, type='')
 
-        assert len(caplog.records) == 0
+        assert response is None
 
 
 class TestCallback:

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -66,6 +66,11 @@ class TestSubscription:
         log = caplog.records[0]
         assert log.message == 'Received a photo of type landscape'
 
+    def test_sub_does_not_execute_when_message_attributes_dont_match_criteria(self, caplog):
+        sub_process_landscape_photos({'name': 'my_new_photo.jpeg'}, type='')
+
+        assert len(caplog.records) == 0
+
 
 class TestCallback:
 


### PR DESCRIPTION
### :tophat: What?

Add a new parameter called `filter_by` to the `sub` decorator that filters the messages to be processed. The filtering is based on the message attributes.

### :thinking: Why?

There are messages sent to a subscription that shouldn't be processed.

### :link: Related issue

Refs #35 
