### PR TITLE
Filter by message attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ test: ## run tests quickly with the default Python
 
 coverage: ## generates codecov report
 	coverage run --source rele runtests.py tests
+	coverage report -m
 
 release: clean install-deploy-requirements sdist ## package and upload a release
 	twine upload -u mercadonatech dist/*

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,9 +32,11 @@ Quickstart
 __________
 
 .. toctree::
-   :maxdepth: 2
+    :maxdepth: 2
 
-   quickstart/rele_and_emulator
+    quickstart/rele_and_emulator
+    quickstart/filters
+
 
 Modules
 _______

--- a/docs/quickstart/filters.rst
+++ b/docs/quickstart/filters.rst
@@ -1,0 +1,55 @@
+Filters
+=======
+
+Filter can be used to execute a subscription with specific parameters.
+There's two types of filters, global or passing a filter_by parameter in the
+subscription.
+
+
+Filters by `filter_by` parameter
+________________________________
+
+This filter is a function that is supposed to return a boolean and this function
+is passed as parameter `filter_by` in the subscription.
+
+.. code:: python
+
+    def landscape_filter(kwargs):
+        return kwargs.get('type') == 'landscape'
+
+
+    # This subscription is going to be called if in the `kwargs`
+    # has a key type with value landscape
+
+    @sub(topic='photo-updated', filter_by=landscape_filter)
+    def sub_process_landscape_photos(data, **kwargs):
+        print(f'Received a photo of type {kwargs.get("type")}')
+
+
+
+Global Filter
+_____________
+
+This filter is specified in the settings with the key `FILTER_SUBS_BY`
+that has a function as value.
+In case a subscription has a filter already it's going to use it's own filter.
+
+.. code:: python
+
+    import os
+
+    def landscape_filter(kwargs):
+        return kwargs.get('type') == 'landscape'
+
+    settings = {
+        'APP_NAME': 'test-rele',
+        'GC_PROJECT_ID': os.environ.get('GC_PROJECT_ID')   ,
+        'GC_CREDENTIALS': os.environ.get('GC_CREDENTIALS'),
+        'SUB_PREFIX': 'rele',
+        'MIDDLEWARE': [],
+        'FILTER_SUBS_BY': landscape_filter,
+    }
+
+
+
+

--- a/rele/config.py
+++ b/rele/config.py
@@ -22,7 +22,7 @@ def setup(setting):
     return config
 
 
-def load_subscriptions_from_paths(sub_module_paths, sub_prefix=None):
+def load_subscriptions_from_paths(sub_module_paths, sub_prefix=None, filter_by=None):
     subscriptions = []
     for sub_module_path in sub_module_paths:
         sub_module = importlib.import_module(sub_module_path)
@@ -31,5 +31,9 @@ def load_subscriptions_from_paths(sub_module_paths, sub_prefix=None):
             if isinstance(attribute, Subscription):
                 if sub_prefix and not attribute.prefix:
                     attribute.set_prefix(sub_prefix)
+
+                if filter_by and not attribute.filter_by:
+                    attribute.set_filter_by(filter_by)
+
                 subscriptions.append(attribute)
     return subscriptions

--- a/rele/config.py
+++ b/rele/config.py
@@ -22,7 +22,9 @@ def setup(setting):
     return config
 
 
-def load_subscriptions_from_paths(sub_module_paths, sub_prefix=None, filter_by=None):
+def load_subscriptions_from_paths(
+        sub_module_paths, sub_prefix=None, filter_by=None):
+
     subscriptions = []
     for sub_module_path in sub_module_paths:
         sub_module = importlib.import_module(sub_module_path)

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
         return rele.config.load_subscriptions_from_paths(
             self._discover_subs_modules(),
             settings.RELE['SUB_PREFIX'],
-            settings.RELE['FILTER_SUBS_BY'])
+            settings.RELE.get('FILTER_SUBS_BY'))
 
     def _wait_forever(self):
         self.stdout.write('Consuming subscriptions...')

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     help = 'Start subscriber threads to consume Relé topics.'
 
     def handle(self, *args, **options):
-        subs = self._autodiscover_subs(settings.RELE['SUB_PREFIX'])
+        subs = self._autodiscover_subs()
         self.stdout.write(f'Configuring worker with {len(subs)} '
                           f'subscription(s)...')
         for sub in subs:
@@ -45,9 +45,11 @@ class Command(BaseCommand):
                 self.stdout.write(" * Discovered subs module: %r" % module)
         return subs_modules
 
-    def _autodiscover_subs(self, sub_prefix):
+    def _autodiscover_subs(self):
         return rele.config.load_subscriptions_from_paths(
-            self._discover_subs_modules(), sub_prefix)
+            self._discover_subs_modules(),
+            settings.RELE['SUB_PREFIX'],
+            settings.RELE['FILTER_SUBS_BY'])
 
     def _wait_forever(self):
         self.stdout.write('Consuming subscriptions...')

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -41,13 +41,16 @@ class Subscription:
         if 'published_at' in kwargs:
             kwargs['published_at'] = float(kwargs['published_at'])
 
-        if self._filter_by and not self._filter_by(kwargs):
+        if self._filter_returns_false(kwargs):
             return
 
         return self._func(data, **kwargs)
 
     def __str__(self):
         return f'{self.name} - {self._func.__name__}'
+
+    def _filter_returns_false(self, kwargs):
+        return self._filter_by and not self._filter_by(kwargs)
 
 
 class Callback:

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -41,7 +41,7 @@ class Subscription:
         if 'published_at' in kwargs:
             kwargs['published_at'] = float(kwargs['published_at'])
 
-        if self._filter_by and not self._filter_by(**kwargs):
+        if self._filter_by and not self._filter_by(kwargs):
             return
 
         return self._func(data, **kwargs)

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -16,7 +16,7 @@ class Subscription:
         self.topic = topic
         self._prefix = prefix
         self._suffix = suffix
-        self._filter_by = filter_by
+        self._filter_by = filter_by or (lambda **_: True)
 
     @property
     def name(self):

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -16,7 +16,7 @@ class Subscription:
         self.topic = topic
         self._prefix = prefix
         self._suffix = suffix
-        self._filter_by = filter_by or (lambda **_: True)
+        self._filter_by = filter_by
 
     @property
     def name(self):
@@ -30,14 +30,21 @@ class Subscription:
     def set_prefix(self, prefix):
         self._prefix = prefix
 
+    @property
+    def filter_by(self):
+        return self._filter_by
+
+    def set_filter_by(self, filter_by):
+        self._filter_by = filter_by
+
     def __call__(self, data, **kwargs):
         if 'published_at' in kwargs:
             kwargs['published_at'] = float(kwargs['published_at'])
 
-        if self._filter_by(**kwargs):
-            return self._func(data, **kwargs)
+        if self._filter_by and not self._filter_by(**kwargs):
+            return
 
-        return None
+        return self._func(data, **kwargs)
 
     def __str__(self):
         return f'{self.name} - {self._func.__name__}'

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -16,7 +16,7 @@ class Subscription:
         self.topic = topic
         self._prefix = prefix
         self._suffix = suffix
-        self._filter_by = filter_by or (lambda **_: True)
+        self._filter_by = filter_by
 
     @property
     def name(self):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -35,7 +35,6 @@ RELE = {
         'rele.contrib.LoggingMiddleware',
         'rele.contrib.DjangoDBMiddleware',
     ],
-    'FILTER_SUBS_BY': lambda attrs: attrs.get('type') == 'foo'
 }
 
 logging_config.dictConfig({

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -35,6 +35,7 @@ RELE = {
         'rele.contrib.LoggingMiddleware',
         'rele.contrib.DjangoDBMiddleware',
     ],
+    'FILTER_SUBS_BY': lambda attrs: attrs.get('type') == 'foo'
 }
 
 logging_config.dictConfig({

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,30 @@
+import pytest
+from rele.config import load_subscriptions_from_paths
+from rele import sub
+
+
+@sub(topic='test-topic', prefix='rele')
+def sub_stub(data, **_kwargs):
+    return data
+
+
+class TestLoadSubscriptions:
+    @pytest.fixture
+    def subscriptions(self):
+        return load_subscriptions_from_paths(
+            ['tests.test_config'],
+            sub_prefix='test',
+            filter_by=lambda **attrs: attrs.get('lang') == 'en')
+
+    def test_load_subscriptions_in_a_module(self, subscriptions):
+        assert len(subscriptions) == 1
+
+    def test_filter_by_applied_to_subscription_returns_true(
+            self, subscriptions):
+
+        assert subscriptions[-1].filter_by(**{'lang': 'en'}) is True
+
+    def test_filter_by_applied_to_subscription_returns_false(
+            self, subscriptions):
+
+        assert subscriptions[0].filter_by(**{'lang': 'es'}) is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,7 @@ class TestLoadSubscriptions:
         return load_subscriptions_from_paths(
             ['tests.test_config'],
             sub_prefix='test',
-            filter_by=lambda **attrs: attrs.get('lang') == 'en')
+            filter_by=lambda attrs: attrs.get('lang') == 'en')
 
     def test_load_subscriptions_in_a_module(self, subscriptions):
         assert len(subscriptions) == 1
@@ -22,9 +22,9 @@ class TestLoadSubscriptions:
     def test_filter_by_applied_to_subscription_returns_true(
             self, subscriptions):
 
-        assert subscriptions[-1].filter_by(**{'lang': 'en'}) is True
+        assert subscriptions[-1].filter_by({'lang': 'en'}) is True
 
     def test_filter_by_applied_to_subscription_returns_false(
             self, subscriptions):
 
-        assert subscriptions[0].filter_by(**{'lang': 'es'}) is False
+        assert subscriptions[0].filter_by({'lang': 'es'}) is False

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -71,6 +71,11 @@ class TestSubscription:
 
         assert response is None
 
+    def test_sub_does_not_execute_when_message_attributes_dont_match_criteria(self, caplog):
+        sub_process_landscape_photos({'name': 'my_new_photo.jpeg'}, type='')
+
+        assert len(caplog.records) == 0
+
 
 class TestCallback:
 

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -71,8 +71,10 @@ class TestSubscription:
 
         assert response is None
 
-    def test_sub_does_not_execute_when_message_attributes_dont_match_criteria(self, caplog):
-        sub_process_landscape_photos({'name': 'my_new_photo.jpeg'}, type='')
+    def test_sub_does_not_execute_when_message_attributes_dont_match_criteria(
+            self, caplog):
+        data = {'name': 'my_new_photo.jpeg'}
+        sub_process_landscape_photos(data, type='')
 
         assert len(caplog.records) == 0
 

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -71,13 +71,6 @@ class TestSubscription:
 
         assert response is None
 
-    def test_sub_does_not_execute_when_message_attributes_dont_match_criteria(
-            self, caplog):
-        data = {'name': 'my_new_photo.jpeg'}
-        sub_process_landscape_photos(data, type='')
-
-        assert len(caplog.records) == 0
-
 
 class TestCallback:
 

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -30,7 +30,7 @@ def sub_published_time_type(data, **kwargs):
     logger.info(f'{type(kwargs["published_at"])}')
 
 
-def landscape_filter(**kwargs):
+def landscape_filter(kwargs):
     return kwargs.get('type') == 'landscape'
 
 


### PR DESCRIPTION
### :tophat: What?

Use default filter_by defined on settings.

`
{
  'FILTER_SUBS_BY': lambda attrs: attrs.get('type') == 'foo'
}
`

### Screenshot
Documentation:

<img width="1116" alt="Screenshot 2019-06-18 at 10 01 44" src="https://user-images.githubusercontent.com/52708/59664115-b9dc3980-91b0-11e9-9dc1-5c9a5460c274.png">


### :thinking: Why?

There's cases where we want to have a default filter for all subscriptions.

### :link: Related issue

Fix #35 