### PR TITLE
Add possibility to use rele in django apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Changelog
 =========
+`0.4.1` Unreleased
+* Ability to install app only with rele
 
 `0.4.0` (2019-06-17)
 

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,5 @@
 __version__ = '0.4.0'
+default_app_config = 'rele.apps.ReleConfig'
 
 from .client import Publisher, Subscriber  # noqa
 from .config import setup  # noqa

--- a/runtests.py
+++ b/runtests.py
@@ -6,6 +6,9 @@ import os
 import sys
 
 import django
+from unittest.mock import patch
+
+from rele.apps import ReleConfig
 
 
 class PytestTestRunner(object):
@@ -44,7 +47,10 @@ def run_tests(*test_args):
         test_args = ['tests']
 
     os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
-    django.setup()
+
+    with patch.object(ReleConfig, 'ready'):
+        django.setup()
+
     test_runner = PytestTestRunner()
     failures = test_runner.run_tests(test_args)
     sys.exit(bool(failures))


### PR DESCRIPTION
### :tophat: What?

Ability to use just rele in the APPS of django settings.

### :thinking: Why?

Without this we need to specify `rele.apps.ReleConfig`.