### PR TITLE
Bump verion with default filter and defalut app config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 Changelog
 =========
-`0.4.1` Unreleased
+`0.4.1` (2019-06-18)
 * Ability to install app only with rele
+* Define default filter_by in settings.RELE
 
 `0.4.0` (2019-06-17)
 

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 default_app_config = 'rele.apps.ReleConfig'
 
 from .client import Publisher, Subscriber  # noqa


### PR DESCRIPTION
### :tophat: What?

Bump rele version with default filters and default app config.

### :thinking: Why?

Fix problems with rele on django settings
