### PR TITLE
Json encoder class is configurable in the Publisher client Class

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+import json
 import os
 import concurrent
 from unittest.mock import ANY, patch
@@ -43,6 +44,19 @@ class TestPublisher:
         publisher._client.publish.assert_called_with(
             ANY, b'{"foo": "bar"}', published_at=str(published_at)
         )
+
+    def test_publishes_data_with_custom_encoder(self, publisher):
+        import decimal
+
+        class DecimalEncoder(json.JSONEncoder):
+            def default(self, obj):
+                if isinstance(obj, decimal.Decimal):
+                    return float(obj)
+
+        publisher._encoder = DecimalEncoder
+        publisher.publish(topic="order-cancelled", data=decimal.Decimal("1.20"))
+
+        publisher._client.publish.assert_called_with(ANY, b"1.2", published_at=ANY)
 
 
 class TestSubscriber:

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -58,15 +58,13 @@ class TestSubscription:
         log2 = caplog.records[0]
         assert log2.message == "I am a task doing stuff with ID 123 (es)"
 
-    def test_sub_executes_when_message_attributes_match_criteria(self, caplog):
+    def test_sub_executes_when_message_attributes_match_criteria(self):
         data = {"name": "my_new_photo.jpeg"}
         response = sub_process_landscape_photos(data, type="landscape")
 
         assert response == "Received a photo of type landscape"
 
-    def test_sub_does_not_execute_when_message_attributes_dont_match_criteria(
-        self, caplog
-    ):
+    def test_sub_does_not_execute_when_message_attributes_dont_match_criteria(self):
         data = {"name": "my_new_photo.jpeg"}
         response = sub_process_landscape_photos(data, type="")
 


### PR DESCRIPTION
### :tophat: What?

Allow the Publisher class to have a configurable json encoder.

### :thinking: Why?

One small step for making the library django dependency free. 

### :link: Related issue

Addresses #8 
