### PR TITLE
Move default ack deadline to the rele config dict

### DIFF
--- a/docs/api/settings.rst
+++ b/docs/api/settings.rst
@@ -28,6 +28,7 @@ Example::
         'SUB_PREFIX': 'mysubprefix',
         'APP_NAME': 'myappname',
         'ENCODER': 'rest_framework.utils.encoders.JSONEncoder',
+        'ACK_DEADLINE': 120,
     }
 
 
@@ -99,5 +100,20 @@ Default: `rest_framework.utils.encoders.JSONEncoder <https://github.com/encode/d
 `Encoder class path <https://docs.python.org/3/library/json.html#json.JSONEncoder>`_ to use for
 serializing your Python data structure to a json object when publishing.
 
-NOTE: The default encoder class is subject to change in an upcoming release. It is
-advised that you use this setting explicitly.
+.. note:: The default encoder class is subject to change in an upcoming release.
+    It is advised that you use this setting explicitly.
+
+``ACK_DEADLINE``
+------------------
+
+**Optional**
+
+Ack deadline for all subscribers in seconds.
+
+
+
+.. seealso:: The `Google Pub/Sub documentation <https://cloud.google.com/pubsub/docs/subscriber>`_
+    which states that *The subscriber has a configurable, limited amount of time --
+    known as the ackDeadline -- to acknowledge the outstanding message. Once the deadline
+    passes, the message is no longer considered outstanding, and Cloud Pub/Sub will attempt
+    to redeliver the message.*

--- a/rele/client.py
+++ b/rele/client.py
@@ -16,21 +16,15 @@ DEFAULT_ENCODER_PATH = "rest_framework.utils.encoders.JSONEncoder"
 
 
 class Subscriber:
-    DEFAULT_ACK_DEADLINE = 60
-
-    def __init__(self, gc_project_id, credentials):
+    def __init__(self, gc_project_id, credentials, default_ack_deadline):
         self._gc_project_id = gc_project_id
+        self._ack_deadline = default_ack_deadline
         if USE_EMULATOR:
             self._client = pubsub_v1.SubscriberClient()
         else:
             self._client = pubsub_v1.SubscriberClient(credentials=credentials)
 
-    def get_default_ack_deadline(self):
-        return int(os.environ.get("DEFAULT_ACK_DEADLINE", self.DEFAULT_ACK_DEADLINE))
-
-    def create_subscription(self, subscription, topic, ack_deadline_seconds=None):
-        ack_deadline_seconds = ack_deadline_seconds or self.get_default_ack_deadline()
-
+    def create_subscription(self, subscription, topic):
         subscription_path = self._client.subscription_path(
             self._gc_project_id, subscription
         )
@@ -40,7 +34,7 @@ class Subscriber:
             self._client.create_subscription(
                 name=subscription_path,
                 topic=topic_path,
-                ack_deadline_seconds=ack_deadline_seconds,
+                ack_deadline_seconds=self._ack_deadline,
             )
 
     def consume(self, subscription_name, callback):

--- a/rele/config.py
+++ b/rele/config.py
@@ -24,8 +24,9 @@ class Config:
         self.app_name = setting.get("APP_NAME")
         self.sub_prefix = setting.get("SUB_PREFIX")
         self.middleware = setting.get("MIDDLEWARE", default_middleware)
-        self.ack_deadline = setting.get("DEFAULT_ACK_DEADLINE",
-                                        os.environ.get("DEFAULT_ACK_DEADLINE", 60))
+        self.ack_deadline = setting.get(
+            "DEFAULT_ACK_DEADLINE", os.environ.get("DEFAULT_ACK_DEADLINE", 60)
+        )
         self._encoder_path = setting.get("ENCODER_PATH", DEFAULT_ENCODER_PATH)
 
     @property

--- a/rele/config.py
+++ b/rele/config.py
@@ -25,7 +25,7 @@ class Config:
         self.sub_prefix = setting.get("SUB_PREFIX")
         self.middleware = setting.get("MIDDLEWARE", default_middleware)
         self.ack_deadline = setting.get(
-            "DEFAULT_ACK_DEADLINE", os.environ.get("DEFAULT_ACK_DEADLINE", 60)
+            "ACK_DEADLINE", os.environ.get("DEFAULT_ACK_DEADLINE", 60)
         )
         self._encoder_path = setting.get("ENCODER_PATH", DEFAULT_ENCODER_PATH)
 

--- a/rele/config.py
+++ b/rele/config.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 
 from .client import DEFAULT_ENCODER_PATH
 from .middleware import register_middleware, default_middleware
@@ -23,6 +24,8 @@ class Config:
         self.app_name = setting.get("APP_NAME")
         self.sub_prefix = setting.get("SUB_PREFIX")
         self.middleware = setting.get("MIDDLEWARE", default_middleware)
+        self.ack_deadline = setting.get("DEFAULT_ACK_DEADLINE",
+                                        os.environ.get("DEFAULT_ACK_DEADLINE", 60))
         self._encoder_path = setting.get("ENCODER_PATH", DEFAULT_ENCODER_PATH)
 
     @property

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -5,8 +5,8 @@ import time
 from django.conf import settings
 from django.core.management import BaseCommand
 
-from rele import Worker
 import rele
+from rele import Worker
 from rele.config import Config
 
 from rele.management.discover import discover_subs_modules

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import signal
 import time
 
@@ -22,7 +23,12 @@ class Command(BaseCommand):
         for sub in subs:
             self.stdout.write(f"  {sub}")
         worker = Worker(
-            subs, settings.RELE["GC_PROJECT_ID"], settings.RELE["GC_CREDENTIALS"]
+            subs,
+            settings.RELE["GC_PROJECT_ID"],
+            settings.RELE["GC_CREDENTIALS"],
+            settings.RELE.get(
+                "DEFAULT_ACK_DEADLINE", os.environ.get("DEFAULT_ACK_DEADLINE", 60)
+            ),
         )
         worker.setup()
         worker.start()

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import signal
 import time
 
@@ -8,6 +7,7 @@ from django.core.management import BaseCommand
 
 from rele import Worker
 import rele
+from rele.config import Config
 
 from rele.management.discover import discover_subs_modules
 
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     help = "Start subscriber threads to consume Relé topics."
+    config = Config(settings.RELE)
 
     def handle(self, *args, **options):
         subs = self._autodiscover_subs()
@@ -24,11 +25,9 @@ class Command(BaseCommand):
             self.stdout.write(f"  {sub}")
         worker = Worker(
             subs,
-            settings.RELE["GC_PROJECT_ID"],
-            settings.RELE["GC_CREDENTIALS"],
-            settings.RELE.get(
-                "DEFAULT_ACK_DEADLINE", os.environ.get("DEFAULT_ACK_DEADLINE", 60)
-            ),
+            self.config.gc_project_id,
+            self.config.credentials,
+            self.config.ack_deadline,
         )
         worker.setup()
         worker.start()
@@ -42,7 +41,7 @@ class Command(BaseCommand):
     def _autodiscover_subs(self):
         return rele.config.load_subscriptions_from_paths(
             discover_subs_modules(),
-            settings.RELE["SUB_PREFIX"],
+            self.config.sub_prefix,
             settings.RELE.get("FILTER_SUBS_BY"),
         )
 

--- a/rele/management/commands/showsubscriptions.py
+++ b/rele/management/commands/showsubscriptions.py
@@ -7,7 +7,7 @@ from rele.management.discover import discover_subs_modules
 
 
 class Command(BaseCommand):
-    help = "List information about Pub/Sub subscriptions " "registered using Relé."
+    help = "List information about Pub/Sub subscriptions registered using Relé."
 
     def handle(self, *args, **options):
         headers = ["Topic", "Subscriber(s)", "Sub"]

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -17,8 +17,8 @@ class Worker:
     :param subscriptions: list :class:`~rele.subscription.Subscription`
     """
 
-    def __init__(self, subscriptions, gc_project_id, credentials):
-        self._subscriber = Subscriber(gc_project_id, credentials)
+    def __init__(self, subscriptions, gc_project_id, credentials, default_ack_deadline):
+        self._subscriber = Subscriber(gc_project_id, credentials, default_ack_deadline)
         self._futures = []
         self._subscriptions = subscriptions
 

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, ANY
 
 from django.core.management import call_command
 
@@ -13,5 +13,6 @@ class TestRunReleCommand:
     ):
         call_command("runrele")
 
+        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60)
         mock_worker.return_value.setup.assert_called()
         mock_worker.return_value.start.assert_called()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def config(credentials, project_id):
 
 @pytest.fixture
 def subscriber(project_id, credentials):
-    return Subscriber(project_id, credentials)
+    return Subscriber(project_id, credentials, 60)
 
 
 @pytest.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -72,32 +72,11 @@ class TestSubscriber:
     ):
         expected_subscription = f"projects/{project_id}/subscriptions/" f"test-topic"
         expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
-
+        subscriber._ack_deadline = 100
         subscriber.create_subscription(
-            "test-topic", f"{project_id}-test-topic", ack_deadline_seconds=100
+            subscription="test-topic", topic=f"{project_id}-test-topic"
         )
 
         _mocked_client.assert_called_once_with(
             ack_deadline_seconds=100, name=expected_subscription, topic=expected_topic
         )
-
-    @patch.object(SubscriberClient, "create_subscription")
-    def test_creates_subscription_with_custom_ack_deadline_from_environment(
-        self, _mocked_client, project_id, subscriber
-    ):
-        expected_subscription = f"projects/{project_id}/subscriptions/" f"test-topic"
-        expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
-
-        with patch.dict(os.environ, {"DEFAULT_ACK_DEADLINE": "200"}):
-            subscriber.create_subscription("test-topic", f"{project_id}-test-topic")
-
-        _mocked_client.assert_called_once_with(
-            ack_deadline_seconds=200, name=expected_subscription, topic=expected_topic
-        )
-
-    def test_get_default_ack_deadline(self, subscriber):
-        assert subscriber.get_default_ack_deadline() == 60
-
-    def test_get_default_ack_deadline_from_environment_variable(self, subscriber):
-        with patch.dict(os.environ, {"DEFAULT_ACK_DEADLINE": "200"}):
-            assert subscriber.get_default_ack_deadline() == 200


### PR DESCRIPTION
### :tophat: What?

In attempt to consolidate all the rele settings out there into one rele dict setting object, here is the moving of the configuration for the default ack_deadline. 

### :link: Related issue

Fix #83 
