### PR TITLE
Remove drf as a dependency

### DIFF
--- a/rele/client.py
+++ b/rele/client.py
@@ -12,7 +12,7 @@ from rele.middleware import run_middleware_hook
 logger = logging.getLogger(__name__)
 
 USE_EMULATOR = True if os.environ.get("PUBSUB_EMULATOR_HOST") else False
-DEFAULT_ENCODER_PATH = "rest_framework.utils.encoders.JSONEncoder"
+DEFAULT_ENCODER_PATH = "json.JSONEncoder"
 
 
 class Subscriber:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,3 @@
 django
-djangorestframework
 google-cloud-pubsub
 tabulate

--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,7 @@ setup(
     url="https://github.com/mercadona/rele",
     packages=find_packages(exclude=("tests",)),
     include_package_data=True,
-    install_requires=[
-        "django",
-        "google-cloud-pubsub",
-        "tabulate",
-    ],
+    install_requires=["django", "google-cloud-pubsub", "tabulate"],
     license="Apache Software License 2.0",
     zip_safe=False,
     keywords="rele",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "django",
-        "djangorestframework",
         "google-cloud-pubsub",
         "tabulate",
     ],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
+import json
+
 import pytest
-from rest_framework.utils.encoders import JSONEncoder
 
 from rele.config import load_subscriptions_from_paths, Config
 from rele import sub
@@ -60,4 +61,4 @@ class TestConfig:
         assert config.gc_project_id is None
         assert config.credentials is None
         assert config.middleware == ["rele.contrib.LoggingMiddleware"]
-        assert config.encoder == JSONEncoder
+        assert config.encoder == json.JSONEncoder


### PR DESCRIPTION
### :tophat: What?

Remove DRF as a project dependency. This is a breaking change.

### :thinking: Why?

Make the project less dependent on django related projects.

### :link: Related issue

#90 
