### PR TITLE
Check max conn age setting and warn when not 0

### DIFF
--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -15,12 +15,20 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = "Start subscriber threads to consume Relé topics."
+    help = "Start subscriber threads to consume messages from Relé topics."
     config = Config(settings.RELE)
 
     def handle(self, *args, **options):
+        if settings.CONN_MAX_AGE != 0:
+            self.stdout.write(self.style.WARNING(
+                'WARNING: settings.CONN_MAX_AGE is not set to 0. '
+                'This may result in slots for database connections to '
+                'be exhausted.'
+            ))
         subs = self._autodiscover_subs()
-        self.stdout.write(f"Configuring worker with {len(subs)} " f"subscription(s)...")
+        self.stdout.write(
+            f"Configuring worker with {len(subs)} " f"subscription(s)..."
+        )
         for sub in subs:
             self.stdout.write(f"  {sub}")
         worker = Worker(

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -19,16 +19,14 @@ class Command(BaseCommand):
     config = Config(settings.RELE)
 
     def handle(self, *args, **options):
-        if settings.CONN_MAX_AGE != 0:
-            self.stdout.write(self.style.WARNING(
+        if all(map(lambda x: x.get('CONN_MAX_AGE'), settings.DATABASES.values())):
+            self.stderr.write(self.style.WARNING(
                 'WARNING: settings.CONN_MAX_AGE is not set to 0. '
                 'This may result in slots for database connections to '
                 'be exhausted.'
             ))
         subs = self._autodiscover_subs()
-        self.stdout.write(
-            f"Configuring worker with {len(subs)} " f"subscription(s)..."
-        )
+        self.stdout.write(f"Configuring worker with {len(subs)} " f"subscription(s)...")
         for sub in subs:
             self.stdout.write(f"  {sub}")
         worker = Worker(

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -19,12 +19,14 @@ class Command(BaseCommand):
     config = Config(settings.RELE)
 
     def handle(self, *args, **options):
-        if all(map(lambda x: x.get('CONN_MAX_AGE'), settings.DATABASES.values())):
-            self.stderr.write(self.style.WARNING(
-                'WARNING: settings.CONN_MAX_AGE is not set to 0. '
-                'This may result in slots for database connections to '
-                'be exhausted.'
-            ))
+        if all(map(lambda x: x.get("CONN_MAX_AGE"), settings.DATABASES.values())):
+            self.stderr.write(
+                self.style.WARNING(
+                    "WARNING: settings.CONN_MAX_AGE is not set to 0. "
+                    "This may result in slots for database connections to "
+                    "be exhausted."
+                )
+            )
         subs = self._autodiscover_subs()
         self.stdout.write(f"Configuring worker with {len(subs)} " f"subscription(s)...")
         for sub in subs:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,6 @@
 pytest>=4.6.0
-coverage>=4.4.0
 pytest-cov>=2.7.0
+pytest-django>=3.5
+coverage>=4.4.0
 codecov>=2.0.0
 black

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,7 @@ use_parentheses=true
 [coverage:run]
 include=*
 omit=*/__init__.py
+
+[tool:pytest]
+filterwarnings =
+    ignore::UserWarning

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -1,18 +1,44 @@
 from unittest.mock import patch, ANY
 
+import pytest
 from django.core.management import call_command
 
 from rele.management.commands.runrele import Command
 
 
 class TestRunReleCommand:
-    @patch.object(Command, "_wait_forever", return_value=None)
-    @patch("rele.management.commands.runrele.Worker", autospec=True)
-    def test_calls_worker_start_and_setup_when_runrele(
-        self, mock_worker, mock_wait_forever
-    ):
+
+    @pytest.fixture(autouse=True)
+    def wait_forever(self):
+        with patch.object(Command, "_wait_forever", return_value=None) as p:
+            yield p
+
+    @pytest.fixture
+    def mock_worker(self):
+        with patch("rele.management.commands.runrele.Worker", autospec=True) as p:
+            yield p
+
+    def test_calls_worker_start_and_setup_when_runrele(self, mock_worker):
         call_command("runrele")
 
+        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60)
+        mock_worker.return_value.setup.assert_called()
+        mock_worker.return_value.start.assert_called()
+
+    def test_prints_warning_when_conn_max_age_not_set_to_zero(
+        self, mock_worker, capsys, settings
+    ):
+        settings.DATABASES = {
+            'default': {
+                'CONN_MAX_AGE': 1,
+            }
+        }
+        call_command("runrele")
+
+        out, err = capsys.readouterr()
+        assert 'WARNING: settings.CONN_MAX_AGE is not set to 0. ' \
+               'This may result in slots for database connections to ' \
+               'be exhausted.' in err
         mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60)
         mock_worker.return_value.setup.assert_called()
         mock_worker.return_value.start.assert_called()

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -7,7 +7,6 @@ from rele.management.commands.runrele import Command
 
 
 class TestRunReleCommand:
-
     @pytest.fixture(autouse=True)
     def wait_forever(self):
         with patch.object(Command, "_wait_forever", return_value=None) as p:
@@ -28,17 +27,15 @@ class TestRunReleCommand:
     def test_prints_warning_when_conn_max_age_not_set_to_zero(
         self, mock_worker, capsys, settings
     ):
-        settings.DATABASES = {
-            'default': {
-                'CONN_MAX_AGE': 1,
-            }
-        }
+        settings.DATABASES = {"default": {"CONN_MAX_AGE": 1}}
         call_command("runrele")
 
         out, err = capsys.readouterr()
-        assert 'WARNING: settings.CONN_MAX_AGE is not set to 0. ' \
-               'This may result in slots for database connections to ' \
-               'be exhausted.' in err
+        assert (
+            "WARNING: settings.CONN_MAX_AGE is not set to 0. "
+            "This may result in slots for database connections to "
+            "be exhausted." in err
+        )
         mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60)
         mock_worker.return_value.setup.assert_called()
         mock_worker.return_value.start.assert_called()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -24,11 +24,7 @@ SITE_ID = 1
 
 MIDDLEWARE_CLASSES = ()
 
-DATABASES = {
-    'default': {
-        'CONN_MAX_AGE': 0,
-    }
-}
+DATABASES = {"default": {"CONN_MAX_AGE": 0}}
 
 RELE = {
     "APP_NAME": "test-rele",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -24,6 +24,12 @@ SITE_ID = 1
 
 MIDDLEWARE_CLASSES = ()
 
+DATABASES = {
+    'default': {
+        'CONN_MAX_AGE': 0,
+    }
+}
+
 RELE = {
     "APP_NAME": "test-rele",
     "GC_PROJECT_ID": "SOME-PROJECT-ID",


### PR DESCRIPTION
### :tophat: What?

Warn the user starting the Relé worker when running `python manage.py runrele` when the database `CONN_MAX_AGE` is not set to 0.

### :thinking: Why?

This can be a severe oversight when setting up Relé leading to the database connections being exhausted. 

### :link: Related issue

Addresses #94 
