### PR TITLE
Add message as a parameter for middleware hooks

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,3 +10,4 @@ Thank you to all the contributors to Relé!
 * Jose Antonio Navarro (@jonasae)
 * Antonio Bustos Rodriguez (@antoniobusrod)
 * David de la Iglesia (@ddelaiglesia) for the Logo!
+* Santiago Lanús (@sanntt)

--- a/docs/api/settings.rst
+++ b/docs/api/settings.rst
@@ -67,6 +67,10 @@ The DjangoDBMiddleware will take care of opening and closing connections to the 
 and after your callbacks are executed. If this is left out, it is highly probable that
 your database will run out of connections in your connection pool.
 
+The LoggingMiddleware will take care of logging subscription information before and after the callback is executed.
+The subscription message is only logged when an exception was raised while processing it.
+If you would like to log this message in every case, you should create a middleware of your own.
+
 
 ``SUB_PREFIX``
 ------------------

--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -40,7 +40,7 @@ class LoggingMiddleware(BaseMiddleware):
             },
         )
 
-    def pre_process_message(self, subscription):
+    def pre_process_message(self, subscription, message):
         self._logger.debug(
             f"Start processing message for {subscription}",
             extra={
@@ -51,7 +51,7 @@ class LoggingMiddleware(BaseMiddleware):
             },
         )
 
-    def post_process_message_success(self, subscription, start_time):
+    def post_process_message_success(self, subscription, start_time, message):
         self._logger.info(
             f"Successfully processed message for {subscription}",
             extra={
@@ -64,7 +64,9 @@ class LoggingMiddleware(BaseMiddleware):
             },
         )
 
-    def post_process_message_failure(self, subscription, exception, start_time):
+    def post_process_message_failure(
+        self, subscription, exception, start_time, message
+    ):
         self._logger.error(
             f"Exception raised while processing message "
             f"for {subscription}: {str(exception.__class__.__name__)}",
@@ -75,7 +77,8 @@ class LoggingMiddleware(BaseMiddleware):
                     "data": self._build_data_metrics(
                         subscription, "failed", start_time
                     ),
-                }
+                },
+                "subscription_message": message,
             },
         )
 

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -34,16 +34,18 @@ class BaseMiddleware:
     def post_publish(self, topic):
         pass
 
-    def pre_process_message(self, subscription):
+    def pre_process_message(self, subscription, message):
         pass
 
     def post_process_message(self):
         pass
 
-    def post_process_message_success(self, subscription, start_time):
+    def post_process_message_success(self, subscription, start_time, message):
         pass
 
-    def post_process_message_failure(self, subscription, exception, start_time):
+    def post_process_message_failure(
+        self, subscription, exception, start_time, message
+    ):
         pass
 
     def pre_worker_start(self):

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -60,7 +60,7 @@ class Callback:
         self._suffix = suffix
 
     def __call__(self, message):
-        run_middleware_hook("pre_process_message", self._subscription)
+        run_middleware_hook("pre_process_message", self._subscription, message)
         start_time = time.time()
 
         data = json.loads(message.data.decode("utf-8"))
@@ -69,12 +69,16 @@ class Callback:
             res = self._subscription(data, **dict(message.attributes))
         except Exception as e:
             run_middleware_hook(
-                "post_process_message_failure", self._subscription, e, start_time
+                "post_process_message_failure",
+                self._subscription,
+                e,
+                start_time,
+                message,
             )
         else:
             message.ack()
             run_middleware_hook(
-                "post_process_message_success", self._subscription, start_time
+                "post_process_message_success", self._subscription, start_time, message
             )
             return res
         finally:

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -174,6 +174,7 @@ class TestCallback:
                 "duration_seconds": pytest.approx(0.5, abs=0.5),
             },
         }
+        assert failed_log.subscription_message == message_wrapper
 
     def test_published_time_as_message_attribute(self, message_wrapper, caplog):
         callback = Callback(sub_published_time_type)


### PR DESCRIPTION
### :tophat: What?

Added the subscription message as a parameter for some middleware hooks:
```python
pre_process_message
post_process_message_success
post_process_message_failure
``` 

In the case of `post_process_message_failure`, the message was also added as an extra in the `LoggingMiddleware`

### :thinking: Why?
Clients might want to log the message in middlewares, and right now, as it is not received in the hooks.

### :link: Related issue

Fix #98 
