### PR TITLE
Safely install Django middleware from __init__.py

### DIFF
--- a/rele/contrib/__init__.py
+++ b/rele/contrib/__init__.py
@@ -1,2 +1,6 @@
 from .logging_middleware import LoggingMiddleware  # noqa
-from .django_db_middleware import DjangoDBMiddleware  # noqa
+
+try:
+    from .django_db_middleware import DjangoDBMiddleware  # noqa
+except ImportError:
+    pass


### PR DESCRIPTION
### :tophat: What?

Test Django Middleware from `__init__.py`

### :thinking: Why?

When using Relé as standalone, the import from `__init__.py` occurs when registering the middleware. This in turn loads that module which has a Django reference. This reference when standalone does not exist. 

As such, one approach is to test the existence of Django, and then import it. 

<img width="1079" alt="Screen Shot 2019-09-29 at 11 20 10 AM" src="https://user-images.githubusercontent.com/14836934/65829971-5d0e1600-e2ab-11e9-83d3-2be4c43ca0c2.png">
