### PR TITLE
Split django specific docs and standalone docs

### DIFF
--- a/docs/api/settings.rst
+++ b/docs/api/settings.rst
@@ -1,3 +1,5 @@
+.. _settings:
+
 ========
 Settings
 ========

--- a/docs/guides/basics.rst
+++ b/docs/guides/basics.rst
@@ -39,7 +39,11 @@ To configure Relé, our settings may look something like:
     import rele
     from settings import config
 
-    data = {'customer_id': 123}
+    data = {
+        'customer_id': 123,
+        'location': '/google-bucket/photos/123.jpg'
+    }
+
     rele.publish(topic='photo-uploaded', data=data)
 
 To publish we simple pass in the topic to which we want our data to publish too, followed by
@@ -71,8 +75,10 @@ In an app directory, we create our sub function within our subs.py file.
 
     @sub(topic='photo-uploaded')
     def photo_uploaded(data, **kwargs):
-        print(f"Someone has uploaded an image to our service, "
-              f"and we stored it at { data['location'] }.")
+        print(f"Customer {data['customer_id']} has uploaded an image to our service,
+                and we stored it at {data['location'}.")
+
+Once the sub is created, we can start our worker by running ``python manage.py runrele``.
 
 Additionally, if you added message attributes to your Message, you can access them via the
 `kwargs` argument:
@@ -81,8 +87,8 @@ Additionally, if you added message attributes to your Message, you can access th
 
     @sub(topic='photo-uploaded')
     def photo_uploaded(data, **kwargs):
-        print(f"Someone has uploaded an image to our service,
-                and we stored it at {data['google_bucket_location'}.
+        print(f"Customer {data['customer_id']} has uploaded an image to our service,
+                and we stored it at {data['location'}.
                 It is a {kwargs['type']} picture with the
                 rotation {kwargs['rotation']}")
 
@@ -98,7 +104,7 @@ To access this attribute you can use `kwargs` keyword.
 
     @sub(topic='photo-uploaded')
     def photo_uploaded(data, **kwargs):
-        print(f"Someone has uploaded an image to our service,
+        print(f"Customer {data['customer_id']} has uploaded an image to our service,
                 and it was published at {kwargs['published_at'}.")
 
 

--- a/docs/guides/basics.rst
+++ b/docs/guides/basics.rst
@@ -1,3 +1,5 @@
+.. _basics:
+
 Basic Usage
 ===========
 
@@ -9,7 +11,7 @@ In order to get started using Relé, we must have a PubSub topic in which to pub
 Via the `Google Cloud Console <https://cloud.google.com/pubsub/docs/quickstart-console>`_
 we create one, named ``photo-upload``.
 
-To authenticate our pubslisher and subscriber, follow the
+To authenticate our publisher and subscriber, follow the
 `Google guide <https://cloud.google.com/pubsub/docs/authentication>`_ on
 how to obtain your authentication account.
 
@@ -20,32 +22,24 @@ To configure Relé, our settings may look something like:
 
 .. code:: python
 
+    # settings.py
+    import rele
     from google.oauth2 import service_account
+
     RELE = {
         'GC_CREDENTIALS': service_account.Credentials.from_service_account_file(
-            'photo_project/settings/dummy-credentials.json'
+            'credentials.json'
         ),
-        'GC_PROJECT_ID': 'photo-imaging',
-        'MIDDLEWARE': [
-            'rele.contrib.LoggingMiddleware',
-            'rele.contrib.DjangoDBMiddleware',
-        ],
-        'APP_NAME': 'photo-imaging',
+        'GC_PROJECT_ID': 'photo-uploading-app',
     }
-
-.. important:: If you plan on having your subscriber connect to the database, it is vital that the Django settings.CONN_MAX_AGE is set to 0.
-
-
-Once the topic is created and our Django application has the proper configuration defined
-in :doc:`settings.RELE <../api/settings>`, we can start publishing to that topic.
-
+    config = rele.config.setup(RELE)
 
 .. code:: python
 
     import rele
+    from settings import config
 
-    data = {'google_bucket_location': '/google-bucket/photos/123.jpg'}
-
+    data = {'customer_id': 123}
     rele.publish(topic='photo-uploaded', data=data)
 
 To publish we simple pass in the topic to which we want our data to publish too, followed by
@@ -62,6 +56,7 @@ If you need to pass in additional attributes to the Message object, you can simp
                  type='profile',
                  rotation='landscape')
 
+.. _subscribing:
 
 Subscribing
 ___________
@@ -71,14 +66,13 @@ In an app directory, we create our sub function within our subs.py file.
 
 .. code:: python
 
+    # subs.py
     from rele import sub
 
     @sub(topic='photo-uploaded')
     def photo_uploaded(data, **kwargs):
-        print(f"Someone has uploaded an image to our service,
-                and we stored it at {data['google_bucket_location'}.")
-
-Once the sub is created, we can start our worker by running ``python manage.py runrele``.
+        print(f"Someone has uploaded an image to our service, "
+              f"and we stored it at { data['location'] }.")
 
 Additionally, if you added message attributes to your Message, you can access them via the
 `kwargs` argument:
@@ -96,7 +90,7 @@ Additionally, if you added message attributes to your Message, you can access th
 Message attributes
 ------------------
 
-It might be helpful to access to particular message attributes in your
+It might be helpful to access particular message attributes in your
 subscriber. One attribute that _rele_ adds by default is `published_at`.
 To access this attribute you can use `kwargs` keyword.
 
@@ -108,9 +102,29 @@ To access this attribute you can use `kwargs` keyword.
                 and it was published at {kwargs['published_at'}.")
 
 
+.. _consuming:
+
 Consuming
 _________
 
-The Relé worker process will autodiscover any properly decorated sub
-function in the subs.py filed and create the subscription for us.
-Once the process is up and running, we can publish and consume.
+Once the sub is implemented, we can start our worker which will register the subscriber with Google Cloud
+and will begin to pull the messages from the topic.
+
+.. code:: python
+
+    from time import sleep
+    from rele import Worker
+
+    from settings import config
+    from subs import photo_uploaded
+
+    if __name__ == '__main__':
+        worker = Worker(
+            [photo_uploaded],
+            config.gc_project_id,
+            config.credentials,
+            config.ack_deadline,
+        )
+        worker.setup()
+        worker.start()
+        sleep(120)

--- a/docs/guides/django.rst
+++ b/docs/guides/django.rst
@@ -1,0 +1,58 @@
+.. _django_integration:
+
+Django Integration
+==================
+
+.. note::
+    This guide simply points out the differences between standalone Relé and
+    the Django integration. The basics about publishing and subscribing are described
+    in the :ref:`basics` section.
+
+Publishing
+__________
+
+To configure Relé, our settings may look something like:
+
+.. code:: python
+
+    from google.oauth2 import service_account
+    RELE = {
+        'GC_CREDENTIALS': service_account.Credentials.from_service_account_file(
+            'photo_project/settings/dummy-credentials.json'
+        ),
+        'GC_PROJECT_ID': 'photo-imaging',
+        'MIDDLEWARE': [
+            'rele.contrib.LoggingMiddleware',
+            'rele.contrib.DjangoDBMiddleware',
+        ],
+        'APP_NAME': 'photo-imaging',
+    }
+
+The only major difference here is that we are using the ``rele.contrib.DjangoDBMiddleware``.
+This is important to properly close DB connections.
+
+.. important::
+    If you plan on having your subscriber connect to the database, it is vital that
+    the Django settings.CONN_MAX_AGE is set to 0.
+
+
+Once the topic is created and our Django application has the proper configuration defined
+in :ref:`settings`, we can start publishing to that topic.
+
+
+Subscribing
+___________
+
+:ref:`subscribing` follows the same method as before.
+
+
+Consuming
+_________
+
+Unlike what is described in :ref:`consuming`, the Django integration provides a very convenient
+command.
+
+By running ``python manage.py runrele``, worker process will autodiscover any properly decorated sub
+function in the subs.py filed and create the subscription for us.
+
+Once the process is up and running, we can publish and consume.

--- a/docs/guides/filters.rst
+++ b/docs/guides/filters.rst
@@ -42,11 +42,7 @@ In case a subscription has a filter already it's going to use it's own filter.
         return kwargs.get('type') == 'landscape'
 
     settings = {
-        'APP_NAME': 'test-rele',
-        'GC_PROJECT_ID': os.environ.get('GC_PROJECT_ID')   ,
-        'GC_CREDENTIALS': os.environ.get('GC_CREDENTIALS'),
-        'SUB_PREFIX': 'rele',
-        'MIDDLEWARE': [],
+        ...
         'FILTER_SUBS_BY': landscape_filter,
     }
 

--- a/docs/guides/rele_and_emulator.rst
+++ b/docs/guides/rele_and_emulator.rst
@@ -1,5 +1,5 @@
 Using the Google Cloud Pub/Sub emulator
-===========================================================
+=======================================
 
 It can be helpful to be able run the emulator in our development environment.
 To be able to do that we can follow the steps below:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ ______
     :maxdepth: 1
 
     guides/basics
+    guides/django
     guides/filters
     guides/rele_and_emulator
 

--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -46,7 +46,7 @@ class LoggingMiddleware(BaseMiddleware):
         )
 
     def pre_process_message(self, subscription, message):
-        self._logger.debug(
+        self._logger.info(
             f"Start processing message for {subscription}",
             extra={
                 "metrics": {

--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -46,7 +46,7 @@ class LoggingMiddleware(BaseMiddleware):
         )
 
     def pre_process_message(self, subscription, message):
-        self._logger.info(
+        self._logger.debug(
             f"Start processing message for {subscription}",
             extra={
                 "metrics": {


### PR DESCRIPTION
### :tophat: What?

Add Django and standalone documentation.

![Screen Shot 2019-10-18 at 5 50 40 PM](https://user-images.githubusercontent.com/14836934/67108998-e68c7600-f1cf-11e9-9b01-6869689a0337.png)
![Screen Shot 2019-10-18 at 5 50 47 PM](https://user-images.githubusercontent.com/14836934/67108997-e5f3df80-f1cf-11e9-9ff1-f4302433afd3.png)
![Screen Shot 2019-10-18 at 5 50 56 PM](https://user-images.githubusercontent.com/14836934/67108995-e5f3df80-f1cf-11e9-97c3-24732f5bd757.png)

### :thinking: Why?

Preparing for the 0.7.0 release which remove django as a requirement

### :link: Related issue

#104 
