### PR TITLE
Add python 3.8 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ language: python
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 
 install:
   - make install-requirements

--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,6 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )


### PR DESCRIPTION
### :tophat: What?

Add python 3.8 to travis.

### :thinking: Why?

[It was officially released on Oct 14, 2019](https://www.python.org/downloads/release/python-380/)

This would allow us to officially add Python 3.8. However, it seems that grpcio is not compiled for Python 3.8 and therefore the [travis build takes much longer to complete.](https://travis-ci.org/mercadona/rele/jobs/601163949). Ran for 5 min 40 sec. 

So either we can wait and not support 3.8 yet, or merge this and have the travis build take longer than expected. 

I leave it as a draft until we decide. 