### PR TITLE
New worker initialization format

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,3 +11,4 @@ Thank you to all the contributors to Relé!
 * David de la Iglesia (@ddelaiglesia) for the Logo!
 * Santiago Lanús (@sanntt)
 * Craig Mulligan (@hobochild)
+* Emilio Carrión (@EmilioCarrion)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+`0.9.0` (2019-11-27)
+* Flask support via middleware (#127)
+* Add message attributes to metrics log (#128)
+
 `0.8.1` (2019-11-25)
 * Fix runrele command
 

--- a/docs/guides/basics.rst
+++ b/docs/guides/basics.rst
@@ -128,12 +128,7 @@ and will begin to pull the messages from the topic.
     from subs import photo_uploaded
 
     if __name__ == '__main__':
-        worker = Worker(
-            [photo_uploaded],
-            config.gc_project_id,
-            config.credentials,
-            config.ack_deadline,
-        )
+        worker = Worker([photo_uploaded], config)
         worker.run_forever()
 
 Once the sub and worker are created, we can start our worker by running ``python worker.py``.

--- a/docs/guides/flask.rst
+++ b/docs/guides/flask.rst
@@ -31,21 +31,25 @@ To configure Relé, our settings may look something like:
     # Later when we setup rele and flask:
     app = Flask()
     rele.config.setup(RELE, flask_app=app)
-```
 
-The only major difference here is that we are using the ``rele.contrib.FlaskMiddleware`` and that we pass the flask app instance to `rele.config.setup` method.
+The only major difference here is that we are using the ``rele.contrib.FlaskMiddleware`` and
+that we pass the Flask ``app`` instance to ``rele.config.setup`` method.
 
 Subscribing
 ____________
 
-Now that that the middleware is setup our subscriptions will automatically have Flasks `app context https://flask.palletsprojects.com/en/1.0.x/appcontext/` pushed when they are invoked so you will have access to the database connection pool and all other app dependent utilities.
+Now that that the middleware is setup our subscriptions will automatically have
+`Flask's app context <https://flask.palletsprojects.com/en/1.0.x/appcontext/>`_ pushed
+when they are invoked so you will have access to the database connection pool and all
+other app dependent utilities.
 
 .. code:: python
-  from models import File
-  from database import db
 
-  @sub(topic='photo-uploads')
-  def handle_upload(data, **kwargs):
-      new_file = File(data)
-      db.session.add(new_file)
-      db.session.commit()
+    from models import File
+    from database import db
+
+    @sub(topic='photo-uploads')
+    def handle_upload(data, **kwargs):
+        new_file = File(data)
+        db.session.add(new_file)
+        db.session.commit()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ Out of the box, Relé includes the following features:
     * Simple publishing API
     * Declarative subscribers
     * Scalable Worker
-    * Ready to install Django integration
+    * Ready to install Django/Flask integration
     * And much more...
 
 What It Looks Like
@@ -73,6 +73,7 @@ ___________
 
     guides/basics
     guides/django
+    guides/flask
     guides/filters
     guides/emulator
 

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.1"
+__version__ = "0.9.0"
 default_app_config = "rele.apps.ReleConfig"
 
 from .client import Publisher, Subscriber  # noqa

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -30,12 +30,7 @@ class Command(BaseCommand):
         self.stdout.write(f"Configuring worker with {len(subs)} " f"subscription(s)...")
         for sub in subs:
             self.stdout.write(f"  {sub}")
-        worker = Worker(
-            subs,
-            self.config.gc_project_id,
-            self.config.credentials,
-            self.config.ack_deadline,
-        )
+        worker = Worker(subs, self.config)
 
         signal.signal(signal.SIGINT, signal.SIG_IGN)
         signal.signal(signal.SIGTERM, worker.stop)

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import time
 
-import rele
+from rele.config import Config
 from .client import Subscriber
 from .middleware import run_middleware_hook
 from .subscription import Callback
@@ -20,7 +20,7 @@ class Worker:
     """
 
     def __init__(self, subscriptions, *args):
-        if args[0] == rele.config:
+        if isinstance(args[0], Config):
             config = args[0]
             gc_project_id, credentials, default_ack_deadline = (
                 config.gc_project_id,

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -2,6 +2,7 @@ import logging
 import sys
 import time
 
+import rele
 from .client import Subscriber
 from .middleware import run_middleware_hook
 from .subscription import Callback
@@ -18,7 +19,18 @@ class Worker:
     :param subscriptions: list :class:`~rele.subscription.Subscription`
     """
 
-    def __init__(self, subscriptions, gc_project_id, credentials, default_ack_deadline):
+    def __init__(self, subscriptions, *args):
+        if args[0] == rele.config:
+            config = args[0]
+            gc_project_id, credentials, default_ack_deadline = (
+                config.gc_project_id,
+                config.credentials,
+                config.ack_deadline,
+            )
+        else:
+            # Keep compatibility
+            gc_project_id, credentials, default_ack_deadline = args
+
         self._subscriber = Subscriber(gc_project_id, credentials, default_ack_deadline)
         self._futures = []
         self._subscriptions = subscriptions

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, ANY
 
 import pytest
+from django.conf import settings
 from django.core.management import call_command
 
 from rele import Worker
@@ -20,11 +21,17 @@ class TestRunReleCommand:
     def test_calls_worker_start_and_setup_when_runrele(self, mock_worker):
         call_command("runrele")
 
+        config = mock_worker.mock_calls[0][1][1]
+        assert (
+            config.gc_project_id == "SOME-PROJECT-ID"
+            and config.credentials == ANY
+            and config.ack_deadline == 60
+        )
         mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60)
         mock_worker.return_value.run_forever.assert_called_once_with()
 
     def test_prints_warning_when_conn_max_age_not_set_to_zero(
-        self, mock_worker, capsys, settings
+        self, mock_worker, capsys
     ):
         settings.DATABASES = {"default": {"CONN_MAX_AGE": 1}}
         call_command("runrele")
@@ -34,6 +41,13 @@ class TestRunReleCommand:
             "WARNING: settings.CONN_MAX_AGE is not set to 0. "
             "This may result in slots for database connections to "
             "be exhausted." in err
+        )
+
+        config = mock_worker.mock_calls[0][1][1]
+        assert (
+            config.gc_project_id == "SOME-PROJECT-ID"
+            and config.credentials == ANY
+            and config.ack_deadline == 60
         )
         mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60)
         mock_worker.return_value.run_forever.assert_called_once_with()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2,7 +2,7 @@ from unittest.mock import ANY, patch
 
 import pytest
 
-from rele import Subscriber, Worker, sub, config
+from rele import Subscriber, Worker, sub
 from rele.middleware import register_middleware
 
 
@@ -12,7 +12,7 @@ def sub_stub(data, **kwargs):
 
 
 @pytest.fixture
-def worker(project_id, credentials):
+def worker(project_id, credentials, config):
     subscriptions = (sub_stub,)
     config.gc_project_id, config.credentials, config.ack_deadline = (
         project_id,
@@ -88,7 +88,7 @@ class TestWorker:
 
     @pytest.mark.usefixtures("mock_create_subscription")
     def test_creates_subscription_with_custom_ack_deadline_from_environment(
-        self, project_id, credentials
+        self, mock_create_subscription, project_id, credentials, config
     ):
         subscriptions = (sub_stub,)
         custom_ack_deadline = 234


### PR DESCRIPTION
### :tophat: What?

Simplified worker initialization.
This allows you to create workers with the rele config directly.
This keeps compatibility with the old initialization format.

### :thinking: Why?

Currently you must pass the config parameters in the worker creation.

### :link: Related issue

This is part of this enhancement issue: https://github.com/mercadona/rele/issues/114
