### PR TITLE
Move dependency to base.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,2 @@
 google-cloud-pubsub
+tabulate

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,2 +1,1 @@
 django
-tabulate


### PR DESCRIPTION
### :tophat: What?

Move `tabulate` dependency from `django` to `base` file.

### :thinking: Why?

`tabulate` dependency is used in `showsubscriptions` command, which has no relation with Django.

