### PR TITLE
Add kwargs to setup method passed through to middleware

### DIFF
--- a/rele/config.py
+++ b/rele/config.py
@@ -36,10 +36,10 @@ class Config:
         return getattr(module, class_name)
 
 
-def setup(setting):
+def setup(setting, **kwargs):
     config = Config(setting)
     init_global_publisher(config)
-    register_middleware(config)
+    register_middleware(config, **kwargs)
     return config
 
 

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -6,7 +6,7 @@ _middlewares = []
 default_middleware = ["rele.contrib.LoggingMiddleware"]
 
 
-def register_middleware(config):
+def register_middleware(config, **kwargs):
     paths = config.middleware
     global _middlewares
     _middlewares = []
@@ -15,7 +15,7 @@ def register_middleware(config):
         module_path = ".".join(module_parts)
         module = importlib.import_module(module_path)
         middleware = getattr(module, middleware_class)()
-        middleware.setup(config)
+        middleware.setup(config, **kwargs)
         _middlewares.append(middleware)
 
 
@@ -30,7 +30,7 @@ class BaseMiddleware:
     subset of hooks they like.
     """
 
-    def setup(self, config):
+    def setup(self, config, **kwargs):
         """Called when middleware is registered.
         :param config: Relé Config object
         """


### PR DESCRIPTION
### :tophat: What?

Add kwargs to the setup method and pass them through to the BaseMiddleware setup function

### :thinking: Why?

Allows users to configure custom configuration for Middleware.

### :link: Related issue

Possible fix for #120 
