### PR TITLE
Fix runrele command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+`0.8.1` (2019-11-25)
+* Fix runrele command
+
 `0.8.0` (2019-11-22)
 * Worker run method (#118)
 * Add kwargs to setup method passed through to middleware (#123)

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 default_app_config = "rele.apps.ReleConfig"
 
 from .client import Publisher, Subscriber  # noqa

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
         signal.signal(signal.SIGTERM, worker.stop)
         signal.signal(signal.SIGTSTP, worker.stop)
 
-        worker.run_forever(sleep_interval=None)
+        worker.run_forever()
 
     def _autodiscover_subs(self):
         return rele.config.load_subscriptions_from_paths(

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -21,7 +21,7 @@ class TestRunReleCommand:
         call_command("runrele")
 
         mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60)
-        mock_worker.return_value.run_forever.assert_called()
+        mock_worker.return_value.run_forever.assert_called_once_with()
 
     def test_prints_warning_when_conn_max_age_not_set_to_zero(
         self, mock_worker, capsys, settings
@@ -36,4 +36,4 @@ class TestRunReleCommand:
             "be exhausted." in err
         )
         mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60)
-        mock_worker.return_value.run_forever.assert_called()
+        mock_worker.return_value.run_forever.assert_called_once_with()


### PR DESCRIPTION
### :tophat: What?

When `runrele` is executed with version `0.8.0`, we received:

```
Traceback (most recent call last):
  File "manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.7/site-packages/rele/management/commands/runrele.py", line 44, in handle
    worker.run_forever(sleep_interval=None)
  File "/usr/local/lib/python3.7/site-packages/rele/worker.py", line 61, in run_forever
    self._wait_forever(sleep_interval=sleep_interval)
  File "/usr/local/lib/python3.7/site-packages/rele/worker.py", line 90, in _wait_forever
    time.sleep(sleep_interval)
TypeError: an integer is required (got type NoneType)
```

### :thinking: Why?

`runforever` should only be accepting integers, not None type
