### PR TITLE
Rele flask

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,10 +3,11 @@ Thank you to all the contributors to Relé!
 * Andrew Graham-Yooll (@andrewgy8)
 * Miquel Torres Barcelo (@tobami)
 * Edgar Latorre (@edgarlatorre)
-* Lluis Guirado (@LluisGuiVi) 
-* Daniel Ruiz (@dani-ruiz) 
+* Lluis Guirado (@LluisGuiVi)
+* Daniel Ruiz (@dani-ruiz)
 * Juanjo Ponz (@jjponz)
 * Jose Antonio Navarro (@jonasae)
 * Antonio Bustos Rodriguez (@antoniobusrod)
 * David de la Iglesia (@ddelaiglesia) for the Logo!
 * Santiago Lanús (@sanntt)
+* Craig Mulligan (@hobochild)

--- a/rele/contrib/__init__.py
+++ b/rele/contrib/__init__.py
@@ -1,4 +1,5 @@
 from .logging_middleware import LoggingMiddleware  # noqa
+from .flask_middleware import FlaskMiddleware  # noqa
 
 try:
     from .django_db_middleware import DjangoDBMiddleware  # noqa

--- a/rele/contrib/flask_middleware.py
+++ b/rele/contrib/flask_middleware.py
@@ -1,0 +1,13 @@
+from rele.middleware import BaseMiddleware
+
+
+class FlaskMiddleware(BaseMiddleware):
+    def setup(self, config, **kwargs):
+        self.app = kwargs["flask_app"]
+
+    def pre_process_message(self, subscription, message):
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
+    def post_process_message(self):
+        self.ctx.pop()

--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -13,7 +13,7 @@ class LoggingMiddleware(BaseMiddleware):
     def __init__(self):
         self._logger = None
 
-    def setup(self, config):
+    def setup(self, config, **kwargs):
         self._logger = logging.getLogger(__name__)
         self._app_name = config.app_name
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,26 @@
+import pytest
+import rele
+from unittest.mock import patch
+
+
+class TestMiddleware:
+    @pytest.fixture
+    def mock_init_global_publisher(self):
+        with patch("rele.config.init_global_publisher", autospec=True) as m:
+            yield m
+
+    @pytest.mark.usefixtures("mock_init_global_publisher")
+    @patch("rele.contrib.FlaskMiddleware.setup", autospec=True)
+    def test_setup_fn_is_called_with_kwargs(
+        self, mock_middleware_setup, project_id, credentials
+    ):
+
+        settings = {
+            "GC_PROJECT_ID": project_id,
+            "GC_CREDENTIALS": credentials,
+            "MIDDLEWARE": ["rele.contrib.FlaskMiddleware"],
+        }
+
+        rele.setup(settings, foo="bar")
+        assert mock_middleware_setup.called
+        mock_middleware_setup.call_args_list[0][-1] == {"foo": "bar"}


### PR DESCRIPTION
### :tophat: What?

Adds middleware for easy integration with Flask and fixes issue with logging Middleware not expecting kwargs.