### PR TITLE
Add message attributes to metrics log

### DIFF
--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -17,7 +17,9 @@ class LoggingMiddleware(BaseMiddleware):
         self._logger = logging.getLogger(__name__)
         self._app_name = config.app_name
 
-    def _build_data_metrics(self, subscription, status, start_processing_time=None):
+    def _build_data_metrics(
+        self, subscription, message, status, start_processing_time=None
+    ):
         result = {
             "agent": self._app_name,
             "topic": subscription.topic,
@@ -51,7 +53,7 @@ class LoggingMiddleware(BaseMiddleware):
             extra={
                 "metrics": {
                     "name": "subscriptions",
-                    "data": self._build_data_metrics(subscription, "received"),
+                    "data": self._build_data_metrics(subscription, message, "received"),
                 }
             },
         )
@@ -63,7 +65,7 @@ class LoggingMiddleware(BaseMiddleware):
                 "metrics": {
                     "name": "subscriptions",
                     "data": self._build_data_metrics(
-                        subscription, "succeeded", start_time
+                        subscription, message, "succeeded", start_time
                     ),
                 }
             },
@@ -80,7 +82,7 @@ class LoggingMiddleware(BaseMiddleware):
                 "metrics": {
                     "name": "subscriptions",
                     "data": self._build_data_metrics(
-                        subscription, "failed", start_time
+                        subscription, message, "failed", start_time
                     ),
                 },
                 "subscription_message": message,

--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -25,6 +25,7 @@ class LoggingMiddleware(BaseMiddleware):
             "topic": subscription.topic,
             "status": status,
             "subscription": subscription.name,
+            "attributes": dict(message.attributes),
         }
 
         if start_processing_time is not None:


### PR DESCRIPTION
### :tophat: What?

Add message `attributes` property to log metrics object.

### :thinking: Why?

Filter log messages by custom message attribute. It is possible than a topic has several subscriptions which filter messages by custom message attribute like `country_code`. Then, it would be nice to filter log messages by same message attribute.

### :link: Related issue

Fixes #113 
