### PR TITLE
Clean up rele.config.setup + Worker() init

### DIFF
--- a/rele/worker.py
+++ b/rele/worker.py
@@ -22,10 +22,10 @@ class Worker:
     def __init__(
         self,
         subscriptions,
-        gc_project_id,
-        credentials,
-        default_ack_deadline,
-        threads_per_subscription,
+        gc_project_id=None,
+        credentials=None,
+        default_ack_deadline=None,
+        threads_per_subscription=None,
     ):
         self._subscriber = Subscriber(gc_project_id, credentials, default_ack_deadline)
         self._futures = []

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,5 +1,6 @@
 from concurrent import futures
 from unittest.mock import ANY, patch
+import os
 
 import pytest
 
@@ -108,3 +109,21 @@ class TestWorker:
         worker.setup()
 
         assert worker._subscriber._ack_deadline == custom_ack_deadline
+
+    @patch.dict(
+        os.environ,
+        {
+            "GOOGLE_APPLICATION_CREDENTIALS": os.path.dirname(
+                os.path.realpath(__file__)
+            )
+            + "/dummy-pub-sub-credentials.json"
+        },
+    )
+    @pytest.mark.usefixtures("mock_create_subscription")
+    def test_creates_without_config(self):
+        subscriptions = (sub_stub,)
+        worker = Worker(subscriptions)
+        worker.setup()
+
+        assert worker._subscriber._ack_deadline == 60
+        assert worker._subscriber._gc_project_id == "rele"


### PR DESCRIPTION
This relates to #114 & #119

This makes makes all config variables nullable falling back to standard
google envars, without breaking the current api.

The new apis would look like this is you have
`GOOGLE_APPLICATION_CREDENTIALS` set.

```
rele.config.setup()
```

```
w = Worker([sub1, sub2])
w.run_forever()
```

TBH, I think reading global configs from the environment is easier to
reason about than a singleton so I'd suggest that. Any non globals should
just be passed into the instances on __init__.

### :tophat: What?

Provide a description of what has been implemented.

### :thinking: Why?

Give an explanation of why.

### :link: Related issue

Add related issue's number. Example: Fix #1
