### PR TITLE
Add publishing timeout

### DIFF
--- a/docs/api/settings.rst
+++ b/docs/api/settings.rst
@@ -31,6 +31,7 @@ Example::
         'APP_NAME': 'myappname',
         'ENCODER_PATH': 'rest_framework.utils.encoders.JSONEncoder',
         'ACK_DEADLINE': 120,
+        'PUBLISHER_TIMEOUT': 3.0
     }
 
 
@@ -116,10 +117,20 @@ serializing your Python data structure to a json object when publishing.
 
 Ack deadline for all subscribers in seconds.
 
-
-
 .. seealso:: The `Google Pub/Sub documentation <https://cloud.google.com/pubsub/docs/subscriber>`_
     which states that *The subscriber has a configurable, limited amount of time --
     known as the ackDeadline -- to acknowledge the outstanding message. Once the deadline
     passes, the message is no longer considered outstanding, and Cloud Pub/Sub will attempt
     to redeliver the message.*
+
+``PUBLISHER_TIMEOUT``
+---------------------
+
+**Optional**
+
+Default: 3.0 seconds
+
+Timeout that the publishing result will wait on the future to publish successfully while blocking.
+
+`See Google PubSub documentation for more info
+<https://googleapis.dev/python/pubsub/1.1.0/publisher/api/futures.html?highlight=result#google.cloud.pubsub_v1.publisher.futures.Future.result>`_

--- a/rele/client.py
+++ b/rele/client.py
@@ -97,7 +97,7 @@ class Publisher:
         else:
             self._client = pubsub_v1.PublisherClient(credentials=credentials)
 
-    def publish(self, topic, data, blocking=False, **attrs):
+    def publish(self, topic, data, blocking=False, timeout=None, **attrs):
         """Publishes message to Google PubSub topic.
 
         Usage::
@@ -114,7 +114,7 @@ class Publisher:
         Usage::
 
             publisher = Publisher()
-            future = publisher.publish('topic_name', {'foo': 'bar'}, blocking=True) # noqa
+            future = publisher.publish('topic_name', {'foo': 'bar'}, blocking=True, timeout=10.0) # noqa
 
         However, it should be noted that using `blocking=True` may incur a
         significant performance hit.
@@ -126,6 +126,7 @@ class Publisher:
         :param topic: string topic to publish the data.
         :param data: dict with the content of the message.
         :param blocking: boolean, default False.
+        :param timeout: float, default 3.0.
         :param attrs: Extra parameters to be published.
         :return: `Future <https://googleapis.github.io/google-cloud-python/latest/pubsub/subscriber/api/futures.html>`_  # noqa
         """
@@ -138,6 +139,6 @@ class Publisher:
         if not blocking:
             return future
 
-        future.result(timeout=self._timeout)
+        future.result(timeout=timeout or self._timeout)
         run_middleware_hook("post_publish", topic)
         return future

--- a/rele/client.py
+++ b/rele/client.py
@@ -85,10 +85,10 @@ class Publisher:
     :param gc_project_id: string Google Cloud Project ID.
     :param credentials: string Google Cloud Credentials.
     :param encoder: A valid `json.encoder.JSONEncoder subclass <https://docs.python.org/3/library/json.html#json.JSONEncoder>`_  # noqa
-    :param timeout: integer, default 3.0 seconds.
+    :param timeout: float
     """
 
-    def __init__(self, gc_project_id, credentials, encoder, timeout=3.0):
+    def __init__(self, gc_project_id, credentials, encoder, timeout):
         self._gc_project_id = gc_project_id
         self._timeout = timeout
         self._encoder = encoder
@@ -97,7 +97,7 @@ class Publisher:
         else:
             self._client = pubsub_v1.PublisherClient(credentials=credentials)
 
-    def publish(self, topic, data, blocking=False, timeout=None, **attrs):
+    def publish(self, topic, data, blocking=False, **attrs):
         """Publishes message to Google PubSub topic.
 
         Usage::
@@ -125,8 +125,7 @@ class Publisher:
 
         :param topic: string topic to publish the data.
         :param data: dict with the content of the message.
-        :param blocking: boolean, default False.
-        :param timeout: float, default 3.0.
+        :param blocking: boolean
         :param attrs: Extra parameters to be published.
         :return: `Future <https://googleapis.github.io/google-cloud-python/latest/pubsub/subscriber/api/futures.html>`_  # noqa
         """
@@ -139,6 +138,6 @@ class Publisher:
         if not blocking:
             return future
 
-        future.result(timeout=timeout or self._timeout)
+        future.result(timeout=self._timeout)
         run_middleware_hook("post_publish", topic)
         return future

--- a/rele/config.py
+++ b/rele/config.py
@@ -28,6 +28,7 @@ class Config:
             "ACK_DEADLINE", os.environ.get("DEFAULT_ACK_DEADLINE", 60)
         )
         self._encoder_path = setting.get("ENCODER_PATH", DEFAULT_ENCODER_PATH)
+        self.publisher_timeout = setting.get("PUBLISHER_TIMEOUT", 3.0)
 
     @property
     def encoder(self):

--- a/rele/publishing.py
+++ b/rele/publishing.py
@@ -10,6 +10,7 @@ def init_global_publisher(config):
             gc_project_id=config.gc_project_id,
             credentials=config.credentials,
             encoder=config.encoder,
+            timeout=config.publisher_timeout,
         )
     return _publisher
 

--- a/rele/publishing.py
+++ b/rele/publishing.py
@@ -34,6 +34,8 @@ def publish(topic, data, **kwargs):
 
     :param topic: str PubSub topic name
     :param data: dict-like Data to be sent as the message.
+    :param timeout: float. Default None, falls back to RELE['PUBLISHER_TIMEOUT'] value
+    :param blocking: boolean. Default False
     :param kwargs: Any optional key-value pairs that are included as attributes
         in the message
     :return: None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,12 @@ def subscriber(project_id, credentials):
 
 @pytest.fixture
 def publisher(config):
-    publisher = Publisher(config.gc_project_id, config.credentials, config.encoder)
+    publisher = Publisher(
+        gc_project_id=config.gc_project_id,
+        credentials=config.credentials,
+        encoder=config.encoder,
+        timeout=config.publisher_timeout,
+    )
     publisher._client = MagicMock(spec=PublisherClient)
     publisher._client.publish.return_value = concurrent.futures.Future()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,7 @@
 import decimal
 import os
 import concurrent
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, patch, MagicMock
 
 import pytest
 from google.cloud.pubsub_v1 import SubscriberClient
@@ -50,6 +50,34 @@ class TestPublisher:
         publisher.publish(topic="order-cancelled", data=decimal.Decimal("1.20"))
 
         publisher._client.publish.assert_called_with(ANY, b"1.2", published_at=ANY)
+
+    @patch.object(concurrent.futures.Future, "result")
+    def test_publishes_data_with_client_timeout_when_blocking(
+        self, mock_future, publisher
+    ):
+        publisher._timeout = 100.0
+        publisher.publish(topic="order-cancelled", data={"foo": "bar"}, blocking=True)
+
+        publisher._client.publish.return_value = mock_future
+        publisher._client.publish.assert_called_with(
+            ANY, b'{"foo": "bar"}', published_at=ANY
+        )
+        mock_future.assert_called_once_with(timeout=100)
+
+    @patch.object(concurrent.futures.Future, "result")
+    def test_publishes_data_with_method_timeout_when_blocking(
+        self, mock_future, publisher
+    ):
+        publisher._timeout = 100.0
+        publisher.publish(
+            topic="order-cancelled", data={"foo": "bar"}, blocking=True, timeout=50.0
+        )
+
+        publisher._client.publish.return_value = mock_future
+        publisher._client.publish.assert_called_with(
+            ANY, b'{"foo": "bar"}', published_at=ANY
+        )
+        mock_future.assert_called_once_with(timeout=50.0)
 
 
 class TestSubscriber:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,6 @@
 import decimal
-import os
 import concurrent
-from unittest.mock import ANY, patch, MagicMock
+from unittest.mock import ANY, patch
 
 import pytest
 from google.cloud.pubsub_v1 import SubscriberClient

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -63,21 +63,6 @@ class TestPublisher:
         )
         mock_future.assert_called_once_with(timeout=100)
 
-    @patch.object(concurrent.futures.Future, "result")
-    def test_publishes_data_with_method_timeout_when_blocking(
-        self, mock_future, publisher
-    ):
-        publisher._timeout = 100.0
-        publisher.publish(
-            topic="order-cancelled", data={"foo": "bar"}, blocking=True, timeout=50.0
-        )
-
-        publisher._client.publish.return_value = mock_future
-        publisher._client.publish.assert_called_with(
-            ANY, b'{"foo": "bar"}', published_at=ANY
-        )
-        mock_future.assert_called_once_with(timeout=50.0)
-
 
 class TestSubscriber:
     @patch.object(SubscriberClient, "create_subscription")

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 from rele import Publisher, publishing
 
 
-class TestPublish:
+class TestInitGlobalPublisher:
     @patch("rele.publishing.Publisher", autospec=True)
     def test_creates_global_publisher_when_published_called(
         self, mock_publisher, config

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -119,7 +119,7 @@ class TestCallback:
                 "topic": "some-cool-topic",
                 "status": "received",
                 "subscription": "rele-some-cool-topic",
-                "attributes": {"lang": "es", "published_at": str(published_at),},
+                "attributes": {"lang": "es", "published_at": str(published_at)},
             },
         }
 
@@ -153,7 +153,7 @@ class TestCallback:
                 "status": "succeeded",
                 "subscription": "rele-some-cool-topic",
                 "duration_seconds": pytest.approx(0.5, abs=0.5),
-                "attributes": {"lang": "es", "published_at": str(published_at),},
+                "attributes": {"lang": "es", "published_at": str(published_at)},
             },
         }
 
@@ -182,7 +182,7 @@ class TestCallback:
                 "status": "failed",
                 "subscription": "rele-some-cool-topic",
                 "duration_seconds": pytest.approx(0.5, abs=0.5),
-                "attributes": {"lang": "es", "published_at": str(published_at),},
+                "attributes": {"lang": "es", "published_at": str(published_at)},
             },
         }
         assert failed_log.subscription_message == message_wrapper


### PR DESCRIPTION
### :tophat: What?

Configurable timeout while waiting for a successful result from the pubsub future. https://googleapis.dev/python/pubsub/1.1.0/publisher/api/futures.html?highlight=result#google.cloud.pubsub_v1.publisher.futures.Future.result

### :thinking: Why?

We would like to control the timeout for publishing.

### :link: Related issue

Addresses #136 
