### PR TITLE
Add subscription ThreadPoolExecutor

### DIFF
--- a/docs/api/settings.rst
+++ b/docs/api/settings.rst
@@ -134,3 +134,13 @@ Timeout that the publishing result will wait on the future to publish successful
 
 `See Google PubSub documentation for more info
 <https://googleapis.dev/python/pubsub/1.1.0/publisher/api/futures.html?highlight=result#google.cloud.pubsub_v1.publisher.futures.Future.result>`_
+
+``THREADS_PER_SUBSCRIPTION``
+------------------
+
+**Optional**
+
+Default: 10
+
+Number of threads that will be consumed for each subscription.
+10 is the default for the Google Cloud PubSub library.

--- a/rele/client.py
+++ b/rele/client.py
@@ -68,9 +68,9 @@ class Subscriber:
         subscription_path = self._client.subscription_path(
             self._gc_project_id, subscription_name
         )
-        return self._client.subscribe(subscription_path,
-                                      callback=callback,
-                                      scheduler=scheduler)
+        return self._client.subscribe(
+            subscription_path, callback=callback, scheduler=scheduler
+        )
 
 
 class Publisher:

--- a/rele/client.py
+++ b/rele/client.py
@@ -57,17 +57,20 @@ class Subscriber:
                 ack_deadline_seconds=self._ack_deadline,
             )
 
-    def consume(self, subscription_name, callback):
+    def consume(self, subscription_name, callback, scheduler):
         """Begin listening to topic from the SubscriberClient.
         
         :param subscription_name: str Subscription name
         :param callback: Function which act on a topic message
+        :param scheduler: `Thread pool-based scheduler.<https://googleapis.dev/python/pubsub/latest/subscriber/api/scheduler.html?highlight=threadscheduler#google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler>`_  # noqa
         :return: `Future <https://googleapis.github.io/google-cloud-python/latest/pubsub/subscriber/api/futures.html>`_  # noqa
         """
         subscription_path = self._client.subscription_path(
             self._gc_project_id, subscription_name
         )
-        return self._client.subscribe(subscription_path, callback=callback)
+        return self._client.subscribe(subscription_path,
+                                      callback=callback,
+                                      scheduler=scheduler)
 
 
 class Publisher:

--- a/rele/config.py
+++ b/rele/config.py
@@ -29,6 +29,7 @@ class Config:
         )
         self._encoder_path = setting.get("ENCODER_PATH", DEFAULT_ENCODER_PATH)
         self.publisher_timeout = setting.get("PUBLISHER_TIMEOUT", 3.0)
+        self.threads_per_subscription = setting.get("THREADS_PER_SUBSCRIPTION", 10)
 
     @property
     def encoder(self):

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -35,6 +35,7 @@ class Command(BaseCommand):
             self.config.gc_project_id,
             self.config.credentials,
             self.config.ack_deadline,
+            self.config.threads_per_subscription,
         )
 
         signal.signal(signal.SIGINT, signal.SIG_IGN)

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -13,14 +13,12 @@ class Subscription:
 
     """
 
-    def __init__(self, func, topic, thread_count, prefix="", suffix="", filter_by=None):
+    def __init__(self, func, topic, prefix="", suffix="", filter_by=None):
         self._func = func
         self.topic = topic
         self._prefix = prefix
         self._suffix = suffix
         self._filter_by = filter_by
-        self._thread_count = thread_count
-        self._scheduler = None
 
     @property
     def name(self):
@@ -56,17 +54,6 @@ class Subscription:
     def _filter_returns_false(self, kwargs):
         return self._filter_by and not self._filter_by(kwargs)
 
-    @property
-    def scheduler(self):
-        if not self._scheduler:
-            executor_kwargs = {
-                "thread_name_prefix": "ThreadPoolExecutor-ThreadScheduler"
-            }
-            self._scheduler = futures.ThreadPoolExecutor(
-                max_workers=self._thread_count, **executor_kwargs
-            )
-        return self._scheduler
-
 
 class Callback:
     def __init__(self, subscription, suffix=None):
@@ -99,7 +86,7 @@ class Callback:
             run_middleware_hook("post_process_message")
 
 
-def sub(topic, prefix=None, suffix=None, filter_by=None, thread_count=10):
+def sub(topic, prefix=None, suffix=None, filter_by=None):
     """Decorator function that makes declaring a PubSub Subscription simple.
 
     The Subscriber returned will automatically create and name
@@ -126,7 +113,7 @@ def sub(topic, prefix=None, suffix=None, filter_by=None, thread_count=10):
         def purpose_1(data, **kwargs):
              pass
 
-        @sub(topic='lets-tell-everyone', suffix='sub2', thread_count=1)
+        @sub(topic='lets-tell-everyone', suffix='sub2')
         def purpose_2(data, **kwargs):
              pass
 
@@ -144,18 +131,12 @@ def sub(topic, prefix=None, suffix=None, filter_by=None, thread_count=10):
     :param filter_by: function An optional function that
                       filters the messages to be processed
                       by the sub regarding their attributes.
-    :param thread_count: Thread count of subscriber. Default 10.
     :return: :class:`~rele.subscription.Subscription`
     """
 
     def decorator(func):
         return Subscription(
-            func=func,
-            topic=topic,
-            prefix=prefix,
-            suffix=suffix,
-            filter_by=filter_by,
-            thread_count=thread_count,
+            func=func, topic=topic, prefix=prefix, suffix=suffix, filter_by=filter_by
         )
 
     return decorator

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -63,8 +63,7 @@ class Subscription:
                 "thread_name_prefix": "ThreadPoolExecutor-ThreadScheduler"
             }
             self._scheduler = futures.ThreadPoolExecutor(
-                max_workers=self._thread_count,
-                **executor_kwargs
+                max_workers=self._thread_count, **executor_kwargs
             )
         return self._scheduler
 
@@ -156,7 +155,7 @@ def sub(topic, prefix=None, suffix=None, filter_by=None, thread_count=10):
             prefix=prefix,
             suffix=suffix,
             filter_by=filter_by,
-            thread_count=thread_count
+            thread_count=thread_count,
         )
 
     return decorator

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -58,15 +58,14 @@ class Subscription:
 
     @property
     def scheduler(self):
-        if self._scheduler:
-            return self._scheduler
-        executor_kwargs = {
-            "thread_name_prefix": "ThreadPoolExecutor-ThreadScheduler"
-        }
-        self._scheduler = futures.ThreadPoolExecutor(
-            max_workers=self._thread_count,
-            **executor_kwargs
-        )
+        if not self._scheduler:
+            executor_kwargs = {
+                "thread_name_prefix": "ThreadPoolExecutor-ThreadScheduler"
+            }
+            self._scheduler = futures.ThreadPoolExecutor(
+                max_workers=self._thread_count,
+                **executor_kwargs
+            )
         return self._scheduler
 
 

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -46,7 +46,9 @@ class Worker:
         for subscription in self._subscriptions:
             self._futures.append(
                 self._subscriber.consume(
-                    subscription_name=subscription.name, callback=Callback(subscription)
+                    subscription_name=subscription.name,
+                    callback=Callback(subscription),
+                    scheduler=subscription.scheduler
                 )
             )
         run_middleware_hook("post_worker_start")

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -48,7 +48,7 @@ class Worker:
                 self._subscriber.consume(
                     subscription_name=subscription.name,
                     callback=Callback(subscription),
-                    scheduler=subscription.scheduler
+                    scheduler=subscription.scheduler,
                 )
             )
         run_middleware_hook("post_worker_start")

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -20,7 +20,7 @@ class TestRunReleCommand:
     def test_calls_worker_start_and_setup_when_runrele(self, mock_worker):
         call_command("runrele")
 
-        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60)
+        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 10)
         mock_worker.return_value.run_forever.assert_called_once_with()
 
     def test_prints_warning_when_conn_max_age_not_set_to_zero(
@@ -35,5 +35,5 @@ class TestRunReleCommand:
             "This may result in slots for database connections to "
             "be exhausted." in err
         )
-        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60)
+        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 10)
         mock_worker.return_value.run_forever.assert_called_once_with()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -36,7 +36,9 @@ class TestWorker:
         worker.start()
 
         mock_consume.assert_called_once_with(
-            subscription_name="rele-some-cool-topic", callback=ANY
+            subscription_name="rele-some-cool-topic",
+            callback=ANY,
+            scheduler=worker._subscriptions[0].scheduler
         )
 
     def test_setup_creates_subscription_when_topic_given(
@@ -58,7 +60,9 @@ class TestWorker:
         subscription = "rele-some-cool-topic"
         mock_create_subscription.assert_called_once_with(subscription, topic)
         mock_consume.assert_called_once_with(
-            subscription_name="rele-some-cool-topic", callback=ANY
+            subscription_name="rele-some-cool-topic",
+            callback=ANY,
+            scheduler=worker._subscriptions[0].scheduler
         )
         mock_wait_forever.assert_called_once()
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -38,7 +38,7 @@ class TestWorker:
         mock_consume.assert_called_once_with(
             subscription_name="rele-some-cool-topic",
             callback=ANY,
-            scheduler=worker._subscriptions[0].scheduler
+            scheduler=worker._subscriptions[0].scheduler,
         )
 
     def test_setup_creates_subscription_when_topic_given(
@@ -62,7 +62,7 @@ class TestWorker:
         mock_consume.assert_called_once_with(
             subscription_name="rele-some-cool-topic",
             callback=ANY,
-            scheduler=worker._subscriptions[0].scheduler
+            scheduler=worker._subscriptions[0].scheduler,
         )
         mock_wait_forever.assert_called_once()
 


### PR DESCRIPTION
### :tophat: What?

Add custom ThreadPoolExecutor to each subscriber. It follows the pattern shown [ here.](https://googleapis.dev/python/pubsub/latest/_modules/google/cloud/pubsub_v1/subscriber/scheduler.html#ThreadScheduler) 

And also allows customer thread count per subscription. 

Note: Ill leave this as a draft since I strongly believe that code coverage can be increased. If this is the direction we want to go, then Ill add it. 

### :thinking: Why?

We want to be able to control the number of thread per subscription. 

### :link: Related issue

Addresses #135 
