### PR TITLE
Dont crash when subscription topic does not exist

### DIFF
--- a/rele/client.py
+++ b/rele/client.py
@@ -74,7 +74,7 @@ class Subscriber:
                     ack_deadline_seconds=self._ack_deadline,
                 )
             except exceptions.NotFound:
-                logger.exception("Cannot subscribe to a topic that does not exist.")
+                logger.error("Cannot subscribe to a topic that does not exist.")
 
     def consume(self, subscription_name, callback, scheduler):
         """Begin listening to topic from the SubscriberClient.

--- a/rele/client.py
+++ b/rele/client.py
@@ -67,11 +67,14 @@ class Subscriber:
         topic_path = self._client.topic_path(self._gc_project_id, topic)
 
         with suppress(exceptions.AlreadyExists):
-            self._client.create_subscription(
-                name=subscription_path,
-                topic=topic_path,
-                ack_deadline_seconds=self._ack_deadline,
-            )
+            try:
+                self._client.create_subscription(
+                    name=subscription_path,
+                    topic=topic_path,
+                    ack_deadline_seconds=self._ack_deadline,
+                )
+            except exceptions.NotFound:
+                logger.exception("Cannot subscribe to a topic that does not exist.")
 
     def consume(self, subscription_name, callback, scheduler):
         """Begin listening to topic from the SubscriberClient.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -113,7 +113,7 @@ class TestSubscriber:
         "create_subscription",
         side_effect=exceptions.NotFound("Subscription topic does not exist"),
     )
-    def test_logs_when_subscription_topic_does_not_exist(
+    def test_logs_error_when_subscription_topic_does_not_exist(
         self, _mocked_client, project_id, subscriber, caplog
     ):
         subscriber.create_subscription(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,7 @@ import concurrent
 from unittest.mock import ANY, patch
 
 import pytest
+from google.api_core import exceptions
 from google.cloud.pubsub_v1 import SubscriberClient
 
 
@@ -92,3 +93,34 @@ class TestSubscriber:
         _mocked_client.assert_called_once_with(
             ack_deadline_seconds=100, name=expected_subscription, topic=expected_topic
         )
+
+    @patch.object(
+        SubscriberClient,
+        "create_subscription",
+        side_effect=exceptions.AlreadyExists("Subscription already exists"),
+    )
+    def test_does_not_raise_when_subscription_already_exists(
+        self, _mocked_client, project_id, subscriber
+    ):
+        subscriber.create_subscription(
+            subscription="test-topic", topic=f"{project_id}-test-topic"
+        )
+
+        _mocked_client.assert_called()
+
+    @patch.object(
+        SubscriberClient,
+        "create_subscription",
+        side_effect=exceptions.NotFound("Subscription topic does not exist"),
+    )
+    def test_logs_when_subscription_topic_does_not_exist(
+        self, _mocked_client, project_id, subscriber, caplog
+    ):
+        subscriber.create_subscription(
+            subscription="test-topic", topic=f"{project_id}-test-topic"
+        )
+
+        _mocked_client.assert_called()
+        log = caplog.records[0]
+        assert log.message == "Cannot subscribe to a topic that does not exist."
+        assert log.levelname == "ERROR"


### PR DESCRIPTION
### :tophat: What?

Catch google.api_core.exceptions.NotFound exception

### :thinking: Why?

Worker should not crash if the topic does not exist. 

### :link: Related issue

Fix #133 
