### PR TITLE
Add unrecoverable_middleware

### DIFF
--- a/docs/guides/unrecoverable_middleware.rst
+++ b/docs/guides/unrecoverable_middleware.rst
@@ -1,0 +1,42 @@
+.. _unrecoverable_middleware:
+
+Unrecoverable Middleware
+===========
+
+To acknowledge and ignore incompatible messages that your subscription will be unable to handle in future you can use the `UnrecoverableMiddleware`.
+
+Usage
+__________
+
+First make sure the middleware is included in your rele config.
+
+.. code:: python
+
+    # settings.py
+    import rele
+    from google.oauth2 import service_account
+
+    RELE = {
+        'GC_CREDENTIALS': service_account.Credentials.from_service_account_file(
+            'credentials.json'
+        ),
+        'GC_PROJECT_ID': 'photo-uploading-app',
+        'MIDDLEWARE': ['rele.contrib.unrecoverable_middleware']
+    }
+    config = rele.config.setup(RELE)
+
+Then in your subscription handler if you encounter a incompatible message raise the `UnrecoverableException`. Your message will be `.acked()` and it will not be redelivered to your subscription.
+
+.. code:: python
+
+    from rele.contrib.unrecoverable_middleware import UnrecoverableException
+    from rele import sub
+
+    @sub(topic='photo-uploaded')
+    def photo_uploaded(data, **kwargs):
+
+      if data.get("required_property") is None:
+          # Incompatible
+          raise UnrecoverableException("required_property is required.")
+
+      # Handle correct messages

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,6 +76,7 @@ ___________
     guides/flask
     guides/filters
     guides/emulator
+    guides/unrecoverable_middleware
 
 
 Configuration

--- a/rele/contrib/unrecoverable_middleware.py
+++ b/rele/contrib/unrecoverable_middleware.py
@@ -8,6 +8,4 @@ class UnrecoverableException(Exception):
 class UnrecoverableMiddleWare(BaseMiddleware):
     def post_process_message_failure(self, subscription, err, start_time, message):
         if isinstance(err, UnrecoverableException):
-            # TODO could add a config or seperate middleware
-            # to push this to a new deadletter queue
             message.ack()

--- a/rele/contrib/unrecoverable_middleware.py
+++ b/rele/contrib/unrecoverable_middleware.py
@@ -1,0 +1,13 @@
+from rele.middleware import BaseMiddleware
+
+
+class UnrecoverableException(Exception):
+    pass
+
+
+class UnrecoverableMiddleWare(BaseMiddleware):
+    def post_process_message_failure(self, subscription, err, start_time, message):
+        if isinstance(err, UnrecoverableException):
+            # TODO could add a config or seperate middleware
+            # to push this to a new deadletter queue
+            message.ack()


### PR DESCRIPTION
This is useful if you know you will never be able to handle the message
and don't have a dead-letter queue setup.

### :tophat: What?

A custom exception and middleware to automate and ignore bad messages.

### :thinking: Why?

I've been using this a fair amount in some of our services and thought it may be useful to others.