### PR TITLE
Adjust default THREADS_PER_SUBSCRIPTION

### DIFF
--- a/docs/api/settings.rst
+++ b/docs/api/settings.rst
@@ -142,7 +142,10 @@ Timeout that the publishing result will wait on the future to publish successful
 
 **Optional**
 
-Default: 10
+Default: 2
 
 Number of threads that will be consumed for each subscription.
-10 is the default for the Google Cloud PubSub library.
+Default behavior of the Google Cloud PubSub library is to use 10 threads per subscription.
+We thought this was too much for a default setting and have taken the liberty of
+reducing the thread count to 2. If you would like to maintain the default Google PubSub
+library behavior, please set this value to 10.

--- a/rele/config.py
+++ b/rele/config.py
@@ -35,7 +35,7 @@ class Config:
         )
         self._encoder_path = setting.get("ENCODER_PATH", DEFAULT_ENCODER_PATH)
         self.publisher_timeout = setting.get("PUBLISHER_TIMEOUT", 3.0)
-        self.threads_per_subscription = setting.get("THREADS_PER_SUBSCRIPTION", 3)
+        self.threads_per_subscription = setting.get("THREADS_PER_SUBSCRIPTION", 2)
 
     @property
     def encoder(self):

--- a/rele/config.py
+++ b/rele/config.py
@@ -35,7 +35,7 @@ class Config:
         )
         self._encoder_path = setting.get("ENCODER_PATH", DEFAULT_ENCODER_PATH)
         self.publisher_timeout = setting.get("PUBLISHER_TIMEOUT", 3.0)
-        self.threads_per_subscription = setting.get("THREADS_PER_SUBSCRIPTION", 10)
+        self.threads_per_subscription = setting.get("THREADS_PER_SUBSCRIPTION", 3)
 
     @property
     def encoder(self):

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -20,7 +20,7 @@ class TestRunReleCommand:
     def test_calls_worker_start_and_setup_when_runrele(self, mock_worker):
         call_command("runrele")
 
-        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 10)
+        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 3)
         mock_worker.return_value.run_forever.assert_called_once_with()
 
     def test_prints_warning_when_conn_max_age_not_set_to_zero(
@@ -35,5 +35,5 @@ class TestRunReleCommand:
             "This may result in slots for database connections to "
             "be exhausted." in err
         )
-        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 10)
+        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 3)
         mock_worker.return_value.run_forever.assert_called_once_with()

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -20,7 +20,7 @@ class TestRunReleCommand:
     def test_calls_worker_start_and_setup_when_runrele(self, mock_worker):
         call_command("runrele")
 
-        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 3)
+        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 2)
         mock_worker.return_value.run_forever.assert_called_once_with()
 
     def test_prints_warning_when_conn_max_age_not_set_to_zero(
@@ -35,5 +35,5 @@ class TestRunReleCommand:
             "This may result in slots for database connections to "
             "be exhausted." in err
         )
-        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 3)
+        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 2)
         mock_worker.return_value.run_forever.assert_called_once_with()


### PR DESCRIPTION
### :tophat: What?

Change [THREADS_PER_SUBSCRIPTION](https://mercadonarele.readthedocs.io/en/latest/api/settings.html#threads-per-subscription) to 2.

### :thinking: Why?

Default thread count is quite high for each subscriber at 10. It would be sensible to opt-in to a higher thread count if necessary.   
