### PR TITLE
🐛 Fix UnrecoverableMiddleWare export and docs

### DIFF
--- a/docs/guides/unrecoverable_middleware.rst
+++ b/docs/guides/unrecoverable_middleware.rst
@@ -3,12 +3,12 @@
 Unrecoverable Middleware
 ===========
 
-To acknowledge and ignore incompatible messages that your subscription will be unable to handle in future you can use the `UnrecoverableMiddleware`.
+To acknowledge and ignore incompatible messages that your subscription is unable to handle, you can use the `UnrecoverableMiddleware`.
 
 Usage
 __________
 
-First make sure the middleware is included in your rele config.
+First make sure the middleware is included in your Relé config.
 
 .. code:: python
 
@@ -21,11 +21,11 @@ First make sure the middleware is included in your rele config.
             'credentials.json'
         ),
         'GC_PROJECT_ID': 'photo-uploading-app',
-        'MIDDLEWARE': ['rele.contrib.unrecoverable_middleware']
+        'MIDDLEWARE': ['rele.contrib.UnrecoverableMiddleWare']
     }
     config = rele.config.setup(RELE)
 
-Then in your subscription handler if you encounter a incompatible message raise the `UnrecoverableException`. Your message will be `.acked()` and it will not be redelivered to your subscription.
+Then in your subscription handler if you encounter an incompatible message raise the `UnrecoverableException`. Your message will be `.acked()` and it will not be redelivered to your subscription.
 
 .. code:: python
 

--- a/rele/contrib/__init__.py
+++ b/rele/contrib/__init__.py
@@ -1,5 +1,6 @@
 from .logging_middleware import LoggingMiddleware  # noqa
 from .flask_middleware import FlaskMiddleware  # noqa
+from .unrecoverable_middleware import UnrecoverableMiddleWare  # noqa
 
 try:
     from .django_db_middleware import DjangoDBMiddleware  # noqa


### PR DESCRIPTION
### :tophat: What?

Add the missing class export line to `rele/contrib/__init__.py` to make it possible to import middleware in config. Also, fix docs.

### :thinking: Why?

It's not working right now 😿 

---

I wasn't really sure how to write a test for it, but if you give me some pointers I'm happy to give it a go!
