### PR TITLE
🐳 Add Dockerfile and commands in Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.8-buster
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+WORKDIR /rele
+LABEL python_version=python
+
+COPY Makefile ./
+COPY requirements requirements/
+
+RUN make install-dev-requirements
+
+COPY . .
+
+CMD ["make", "clean", "lint", "test"]

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,12 @@ install-dev-requirements: install-requirements install-test-requirements install
 build-html-doc: ## builds the project documentation in HTML format
 	DJANGO_SETTINGS_MODULE=tests.settings make html -C docs
 	open docs/_build/html/index.html
+
+docker-build:
+	docker build -t rele .
+
+docker-test: docker-build
+	docker run -it --rm --name rele rele
+
+docker-shell: docker-build
+	docker run -it --rm --name rele --volume ${PWD}:/rele rele /bin/bash


### PR DESCRIPTION
### :tophat: What?

I set up a Dockerfile and commands in Makefile to make it possible to run all tests with a single command and no installation required (if you already have Docker).

### :thinking: Why?

I really detest installing tons of development environments on my laptop, so set this up for myself, but thought why not share.

But in general, spinning things up in a Docker container greatly lowers the barrier to entry for casual contribution.