### PR TITLE
Document attribute type limitations when publishing

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,3 +12,4 @@ Thank you to all the contributors to Relé!
 * Santiago Lanús (@sanntt)
 * Craig Mulligan (@hobochild)
 * Daniel Demmel (@daaain)
+* Luis Garcia Cuesta (@luisgc93)

--- a/docs/guides/basics.rst
+++ b/docs/guides/basics.rst
@@ -53,7 +53,8 @@ a valid json serializable Python object.
 
 .. note:: If you want to publish other types of objects, you may configure the encoder class.
 
-If you need to pass in additional attributes to the Message object, you can simply add ``kwargs``:
+If you need to pass in additional attributes to the Message object, you can simply add ``kwargs``.
+These must all be strings:
 
 .. code:: python
 
@@ -61,6 +62,8 @@ If you need to pass in additional attributes to the Message object, you can simp
                  data=data,
                  type='profile',
                  rotation='landscape')
+
+.. note:: Anything other than a string attribute will result in a ``TypeError``.
 
 .. _subscribing:
 

--- a/rele/client.py
+++ b/rele/client.py
@@ -149,7 +149,7 @@ class Publisher:
         :param data: dict with the content of the message.
         :param blocking: boolean
         :param timeout: float, default None fallsback to :ref:`settings_publisher_timeout`
-        :param attrs: Extra parameters to be published.
+        :param attrs: string, extra parameters to be published.
         :return: `Future <https://googleapis.github.io/google-cloud-python/latest/pubsub/subscriber/api/futures.html>`_  # noqa
         """
 

--- a/rele/client.py
+++ b/rele/client.py
@@ -149,7 +149,7 @@ class Publisher:
         :param data: dict with the content of the message.
         :param blocking: boolean
         :param timeout: float, default None fallsback to :ref:`settings_publisher_timeout`
-        :param attrs: string, extra parameters to be published.
+        :param attrs: additional string parameters to be published.
         :return: `Future <https://googleapis.github.io/google-cloud-python/latest/pubsub/subscriber/api/futures.html>`_  # noqa
         """
 


### PR DESCRIPTION
### :tophat: What?
Document that only strings are allowed when passing additional parameters to the publish method

### :thinking: Why?

This should be documented

### :link: Related issue

Fix #106 
