### PR TITLE
Rewrite Basic's docs to cover the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ seamless by providing Publisher, Subscriber and Worker classes with the followin
 * Intuitive Subscription Management
 * Easily Extensible Middleware
 * Optional Django or Flask Integration
+* CLI
 * And much more!
 
 ## What it looks like

--- a/docs/api/settings.rst
+++ b/docs/api/settings.rst
@@ -96,6 +96,7 @@ The application name.
 This should be unique to all the services running in the application ecosystem. It is used by
 the LoggingMiddleware and Prometheus integration.
 
+.. _settings_encoder_path:
 
 ``ENCODER_PATH``
 ------------------

--- a/rele/config.py
+++ b/rele/config.py
@@ -25,8 +25,8 @@ class Config:
         ):
             credentials, project = get_google_defaults()
 
-        self.gc_project_id = setting.get("GC_PROJECT_ID") or project
         self.credentials = setting.get("GC_CREDENTIALS") or credentials
+        self.gc_project_id = setting.get("GC_PROJECT_ID") or project
         self.app_name = setting.get("APP_NAME")
         self.sub_prefix = setting.get("SUB_PREFIX")
         self.middleware = setting.get("MIDDLEWARE", default_middleware)

--- a/rele/discover.py
+++ b/rele/discover.py
@@ -42,5 +42,5 @@ def sub_modules():
         if is_package and module_has_submodule(package, "subs"):
             module = package + ".subs"
             module_paths.append(module)
-            logger.debug(" * Discovered subs module: %r" % module)
+            logger.info(" * Discovered subs module: %r" % module)
     return settings, module_paths

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -2,7 +2,6 @@ import json
 import logging
 import time
 
-import rele
 from .middleware import run_middleware_hook
 
 logger = logging.getLogger(__name__)

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -1,6 +1,16 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from rele import Publisher, publishing
+
+
+class TestPublish:
+    def test_raises_when_global_publisher_does_not_exist(self):
+        message = {"foo": "bar"}
+
+        with pytest.raises(ValueError):
+            publishing.publish(topic="order-cancelled", data=message, myattr="hello")
 
 
 class TestInitGlobalPublisher:


### PR DESCRIPTION
### :tophat: What?

- Documentation of the cli on the basics section
- Also some linting on unused imports
- Change the debug log in the autodiscover to info

### :thinking: Why?

Its no longer necessary to write your own worker.

### :link: Related issue

#160 

<img width="680" alt="Screen Shot 2020-05-29 at 6 01 16 PM" src="https://user-images.githubusercontent.com/14836934/83280085-6bb02280-a1d6-11ea-8a00-5134e4d0c00c.png">

