### PR TITLE
Bump 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-`0.12.0` (TBD)
+`0.12.0` (2020-6-12)
 * Added `--settings` path option in CLI (#166)
 * Added isort linting (#164)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@ Changelog
 =========
 
 `0.12.0` (TBD)
-* `--settings` option in CLI (#166)
-* isort (#164)
+* Added `--settings` path option in CLI (#166)
+* Added isort linting (#164)
 
 `0.11.0` (2020-6-4)
 * CLI feature (#160)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+`0.12.0` (TBD)
+* `--settings` option in CLI (#166)
+* isort (#164)
+
 `0.11.0` (2020-6-4)
 * CLI feature (#160)
 * Documentation Enhancements (#158, #155, #162)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,15 +13,15 @@
 import os
 import sys
 
-import rele
 
 sys.path.insert(0, os.path.abspath(".."))
 
+import rele
 
 # -- Project information -----------------------------------------------------
 
 project = "Relé"
-copyright = "2019, Mercadona S.A."
+copyright = "2019-2020, Mercadona S.A."
 author = "Mercadona"
 version = rele.__version__
 

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 default_app_config = "rele.apps.ReleConfig"
 
 from .client import Publisher, Subscriber  # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ default_section=THIRDPARTY
 known_first_party=rele
 multi_line_output=3
 use_parentheses=true
+skip=docs/
 
 [coverage:run]
 include=*


### PR DESCRIPTION
### :tophat: What?

Bump to version 0.12.0

Add correct path to the docs/conf.py file.
Dont lint the docs directory

### :thinking: Why?
When isorting, [the conf.py in docs was linted.](https://github.com/mercadona/rele/pull/164/files#diff-85987f48f1258d9ee486e3191495582dR16) This broke the import path.

```
  File "/home/docs/checkouts/readthedocs.org/user_builds/mercadonarele/checkouts/latest/docs/conf.py", line 16, in <module>
    import rele
ModuleNotFoundError: No module named 'rele'
```
### :link: Related issue

#164 
