### PR TITLE
Traverse all packages for subs.py files

### DIFF
--- a/docs/guides/basics.rst
+++ b/docs/guides/basics.rst
@@ -132,7 +132,8 @@ path.
     rele-cli run --settings app.settings
 
 
-.. note:: Autodiscovery of subscribers with ``rele-cli`` follows a strict directory structure.
+.. note:: Autodiscovery of subscribers with ``rele-cli`` is automatic.
+    Any ``subs.py`` module you have in your current path, will be imported, and all subsequent decorated objects will be registered.
 
     | ├──settings.py
     | ├──app # This can be called whatever you like

--- a/rele/discover.py
+++ b/rele/discover.py
@@ -24,6 +24,17 @@ def module_has_submodule(package, module_name):
         return False
 
 
+def _get_subs(module_paths, package):
+    for f, package, is_package in pkgutil.iter_modules(path=__import__(package).__path__):
+        if is_package and module_has_submodule(package, "subs"):
+            module = package + ".subs"
+            module_paths.append(module)
+            print(" * Discovered subs module: %r" % module)
+        if is_package:
+            module_paths = _get_subs(module_paths, package)
+    return module_paths
+
+
 def _import_settings_from_path(path):
     if path is not None:
         print(" * Discovered settings: %r" % path)
@@ -43,11 +54,11 @@ def sub_modules(settings_path=None):
     """
     module_paths = []
     for f, package, is_package in pkgutil.iter_modules(path=["."]):
+        # breakpoint()
         if package == "settings":
             settings_path = package
-        if is_package and module_has_submodule(package, "subs"):
-            module = package + ".subs"
-            module_paths.append(module)
-            print(" * Discovered subs module: %r" % module)
+        if is_package:
+            module_paths = _get_subs(module_paths, package)
+
     settings = _import_settings_from_path(settings_path)
     return settings, module_paths

--- a/tests/more_subs/subs.py
+++ b/tests/more_subs/subs.py
@@ -1,0 +1,6 @@
+from rele import sub
+
+
+@sub(topic="another-cool-topic", prefix="rele")
+def another_sub_stub(data, **kwargs):
+    return data["id"]

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -10,13 +10,13 @@ class TestDiscoverSubModules:
 
         assert discovered_settings is settings
         assert discovered_settings.RELE == settings.RELE
-        assert paths == ["tests.subs"]
+        assert paths == ["tests.subs", "tests.more_subs.subs"]
 
     def test_returns_empty_settings_when_no_settings_module_found(self):
         discovered_settings, paths = discover.sub_modules()
 
         assert discovered_settings is None
-        assert paths == ["tests.subs"]
+        assert paths == ["tests.subs", "tests.more_subs.subs"]
 
     def test_raises_when_incorrect_path(self):
         incorrect_path = "tests.foo"


### PR DESCRIPTION
### :tophat: What?

Traversal of all packages in a Python path and get the path of the `subs.py` file. 

### :thinking: Why?

This way we can have a `subs.py` n-levels deep, and autodiscover it. 

### :link: Related issue

Enhancement of #160 

Here it is working on a local project I have set up.

```
$ rele-cli run --settings test.settings
 * Discovered subs module: 'test.subs'
 * Discovered subs module: 'test.foo.bar.subs'
 * Discovered settings: 'test.settings'
Configuring worker with 2 subscription(s)...
  test-delivery-driver-created - some_sub
  test-another-topic - some_sub
Cannot subscribe to a topic that does not exist.
```

