### PR TITLE
Catch TimeoutError and run post_publish_failure when blocking

### DIFF
--- a/rele/client.py
+++ b/rele/client.py
@@ -171,8 +171,7 @@ class Publisher:
             run_middleware_hook("post_publish_failure", topic, e, data)
             if raise_exception:
                 raise e
-            else:
-                return False
+            return False
 
         run_middleware_hook("post_publish", topic)
         return future

--- a/rele/client.py
+++ b/rele/client.py
@@ -171,7 +171,7 @@ class Publisher:
             run_middleware_hook("post_publish_failure", topic, e, data)
             if raise_exception:
                 raise e
-            return False
+            return future
 
         run_middleware_hook("post_publish", topic)
         return future

--- a/rele/client.py
+++ b/rele/client.py
@@ -171,7 +171,7 @@ class Publisher:
             run_middleware_hook("post_publish_failure", topic, e, data)
             if raise_exception:
                 raise e
-            return future
+        else:
+            run_middleware_hook("post_publish", topic)
 
-        run_middleware_hook("post_publish", topic)
         return future

--- a/rele/client.py
+++ b/rele/client.py
@@ -166,6 +166,7 @@ class Publisher:
             future.result(timeout=timeout or self._timeout)
         except TimeoutError as e:
             run_middleware_hook("post_publish_failure", topic, e, data)
+            raise e
 
         run_middleware_hook("post_publish", topic)
         return future

--- a/rele/client.py
+++ b/rele/client.py
@@ -120,7 +120,8 @@ class Publisher:
         else:
             self._client = pubsub_v1.PublisherClient(credentials=credentials)
 
-    def publish(self, topic, data, blocking=False, timeout=None, **attrs):
+    def publish(self, topic, data, blocking=False, timeout=None, raise_exception=True,
+                **attrs):
         """Publishes message to Google PubSub topic.
 
         Usage::
@@ -146,6 +147,7 @@ class Publisher:
         message attrs using `epoch floating point number
         <https://docs.python.org/3/library/time.html#time.time>`_.
 
+        :param raise_exception: boolean. If True, exceptions coming from PubSub will be raised
         :param topic: string topic to publish the data.
         :param data: dict with the content of the message.
         :param blocking: boolean
@@ -166,7 +168,10 @@ class Publisher:
             future.result(timeout=timeout or self._timeout)
         except TimeoutError as e:
             run_middleware_hook("post_publish_failure", topic, e, data)
-            raise e
+            if raise_exception:
+                raise e
+            else:
+                return False
 
         run_middleware_hook("post_publish", topic)
         return future

--- a/rele/client.py
+++ b/rele/client.py
@@ -2,12 +2,12 @@ import json
 import logging
 import os
 import time
-from concurrent.futures import TimeoutError
 from contextlib import suppress
 
 import google.auth
 from google.api_core import exceptions
 from google.cloud import pubsub_v1
+from google.cloud.pubsub_v1.exceptions import TimeoutError
 
 from rele.middleware import run_middleware_hook
 

--- a/rele/client.py
+++ b/rele/client.py
@@ -161,6 +161,10 @@ class Publisher:
         if not blocking:
             return future
 
-        future.result(timeout=timeout or self._timeout)
+        try:
+            future.result(timeout=timeout or self._timeout)
+        except TimeoutError as e:
+            run_middleware_hook("post_publish_failure")
+
         run_middleware_hook("post_publish", topic)
         return future

--- a/rele/client.py
+++ b/rele/client.py
@@ -148,11 +148,11 @@ class Publisher:
         message attrs using `epoch floating point number
         <https://docs.python.org/3/library/time.html#time.time>`_.
 
-        :param raise_exception: boolean. If True, exceptions coming from PubSub will be raised
         :param topic: string topic to publish the data.
         :param data: dict with the content of the message.
         :param blocking: boolean
-        :param timeout: float, default None fallsback to :ref:`settings_publisher_timeout`
+        :param timeout: float, default None falls back to :ref:`settings_publisher_timeout`
+        :param raise_exception: boolean. If True, exceptions coming from PubSub will be raised
         :param attrs: additional string parameters to be published.
         :return: `Future <https://googleapis.github.io/google-cloud-python/latest/pubsub/subscriber/api/futures.html>`_  # noqa
         """

--- a/rele/client.py
+++ b/rele/client.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import time
+from concurrent.futures import TimeoutError
 from contextlib import suppress
 
 import google.auth

--- a/rele/client.py
+++ b/rele/client.py
@@ -120,8 +120,9 @@ class Publisher:
         else:
             self._client = pubsub_v1.PublisherClient(credentials=credentials)
 
-    def publish(self, topic, data, blocking=False, timeout=None, raise_exception=True,
-                **attrs):
+    def publish(
+        self, topic, data, blocking=False, timeout=None, raise_exception=True, **attrs
+    ):
         """Publishes message to Google PubSub topic.
 
         Usage::

--- a/rele/client.py
+++ b/rele/client.py
@@ -165,7 +165,7 @@ class Publisher:
         try:
             future.result(timeout=timeout or self._timeout)
         except TimeoutError as e:
-            run_middleware_hook("post_publish_failure")
+            run_middleware_hook("post_publish_failure", topic, e, data)
 
         run_middleware_hook("post_publish", topic)
         return future

--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -50,7 +50,7 @@ class LoggingMiddleware(BaseMiddleware):
 
     def post_publish_failure(self, topic, exception, message):
         self._logger.exception(
-            f"Exception raised while processing message "
+            f"Exception raised while publishing message "
             f"for {topic}: {str(exception.__class__.__name__)}",
             exc_info=True,
             extra={

--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -48,6 +48,20 @@ class LoggingMiddleware(BaseMiddleware):
             },
         )
 
+    def post_publish_failure(self, topic, exception, message):
+        self._logger.exception(
+            f"Exception raised while processing message "
+            f"for {topic}: {str(exception.__class__.__name__)}",
+            exc_info=True,
+            extra={
+                "metrics": {
+                    "name": "publications",
+                    "data": {"agent": self._app_name, "topic": topic},
+                },
+                "subscription_message": message,
+            },
+        )
+
     def pre_process_message(self, subscription, message):
         self._logger.debug(
             f"Start processing message for {subscription}",

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -47,9 +47,11 @@ class BaseMiddleware:
         :param topic:
         """
 
-    def post_publish_failure(self, topic):
-        """Called after Publisher fails.
+    def post_publish_failure(self, topic, exception, message):
+        """Called after publishing fails.
         :param topic:
+        :param exception:
+        :param message:
         """
 
     def pre_process_message(self, subscription, message):

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -47,6 +47,11 @@ class BaseMiddleware:
         :param topic:
         """
 
+    def post_publish_failure(self, topic):
+        """Called after Publisher fails.
+        :param topic:
+        """
+
     def pre_process_message(self, subscription, message):
         """Called when the Worker receives a message.
         :param subscription:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,6 +93,6 @@ def mock_publish_timeout():
 
 
 @pytest.fixture
-def mock_post_process_message_failure():
-    with patch("rele.middleware.BaseMiddleware.post_process_message_failure") as mock:
+def mock_post_publish_failure():
+    with patch("rele.middleware.BaseMiddleware.post_publish_failure") as mock:
         yield mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 import concurrent
 import decimal
 import json
-from concurrent.futures import TimeoutError
 from unittest.mock import MagicMock, patch
 
 import pytest
 from google.cloud.pubsub_v1 import PublisherClient
+from google.cloud.pubsub_v1.exceptions import TimeoutError
 from google.oauth2 import service_account
 
 from rele import Publisher

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,12 @@ def subscriber(project_id, credentials):
 
 
 @pytest.fixture
-def publisher(config):
+def mock_future():
+    return MagicMock(spec=concurrent.futures.Future)
+
+
+@pytest.fixture
+def publisher(config, mock_future):
     publisher = Publisher(
         gc_project_id=config.gc_project_id,
         credentials=config.credentials,
@@ -53,7 +58,7 @@ def publisher(config):
         timeout=config.publisher_timeout,
     )
     publisher._client = MagicMock(spec=PublisherClient)
-    publisher._client.publish.return_value = concurrent.futures.Future()
+    publisher._client.publish.return_value = mock_future
 
     return publisher
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,5 +99,7 @@ def mock_publish_timeout():
 
 @pytest.fixture
 def mock_post_publish_failure():
-    with patch("rele.middleware.BaseMiddleware.post_publish_failure") as mock:
+    with patch(
+        "rele.contrib.logging_middleware.LoggingMiddleware.post_publish_failure"
+    ) as mock:
         yield mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,3 +82,16 @@ def custom_encoder():
                 return float(obj)
 
     return DecimalEncoder
+
+
+@pytest.fixture
+def mock_publish_timeout():
+    with patch("rele.client.Publisher.publish") as mock:
+        mock.side_effect = TimeoutError()
+        yield mock
+
+
+@pytest.fixture
+def mock_post_process_message_failure():
+    with patch("rele.middleware.BaseMiddleware.post_process_message_failure") as mock:
+        yield mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import concurrent
 import decimal
 import json
+from concurrent.futures import TimeoutError
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -82,13 +82,14 @@ class TestPublisher:
 
     @pytest.mark.usefixtures("mock_publish_timeout")
     def test_runs_post_publish_failure_hook_when_time_out_error(
-        self, publisher, mock_post_process_message_failure
+        self, publisher, mock_post_publish_failure
     ):
         message = {"foo": "bar"}
 
         with pytest.raises(TimeoutError):
             publisher.publish(topic="order-cancelled", data=message, myattr="hello")
-            mock_post_process_message_failure.assert_called_once()
+            mock_post_publish_failure.assert_called_once_with(
+                topic="order-cancelled", exception=TimeoutError, message={"foo": "bar"})
 
 
 class TestSubscriber:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -89,7 +89,8 @@ class TestPublisher:
         with pytest.raises(TimeoutError):
             publisher.publish(topic="order-cancelled", data=message, myattr="hello")
             mock_post_publish_failure.assert_called_once_with(
-                topic="order-cancelled", exception=TimeoutError, message={"foo": "bar"})
+                topic="order-cancelled", exception=TimeoutError, message={"foo": "bar"}
+            )
 
 
 class TestSubscriber:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -78,7 +78,7 @@ class TestPublisher:
         )
         mock_future.result.assert_called_once_with(timeout=50)
 
-    def test_runs_post_publish_failure_hook_when_time_out_error(
+    def test_runs_post_publish_failure_hook_when_future_result_raises_timeout(
         self, mock_future, publisher, mock_post_publish_failure
     ):
         message = {"foo": "bar"}
@@ -93,7 +93,7 @@ class TestPublisher:
             "order-cancelled", e, {"foo": "bar"}
         )
 
-    def test_raises_when_time_out_error_and_raise_exception_is_true(
+    def test_raises_when_timeout_error_and_raise_exception_is_true(
         self, publisher, mock_future
     ):
         message = {"foo": "bar"}
@@ -108,7 +108,7 @@ class TestPublisher:
                 raise_exception=True,
             )
 
-    def test_returns_false_when_time_out_error_and_raise_exception_is_false(
+    def test_returns_false_when_timeout_error_and_raise_exception_is_false(
         self, publisher, mock_future
     ):
         message = {"foo": "bar"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -92,6 +92,28 @@ class TestPublisher:
             "order-cancelled", e, {"foo": "bar"}
         )
 
+    def test_raises_when_time_out_error_and_raise_exception_is_true(
+            self, publisher, mock_future):
+        message = {"foo": "bar"}
+        e = TimeoutError()
+        mock_future.result.side_effect = e
+        with pytest.raises(TimeoutError):
+            publisher.publish(topic="order-cancelled", data=message, myattr="hello",
+                              blocking=True, raise_exception=True)
+
+    def test_returns_false_when_time_out_error_and_raise_exception_is_false(
+            self, publisher, mock_future):
+        message = {"foo": "bar"}
+        e = TimeoutError()
+        mock_future.result.side_effect = e
+
+        result = publisher.publish(topic="order-cancelled",
+                                   data=message,
+                                   myattr="hello",
+                                   blocking=True,
+                                   raise_exception=False)
+        assert result is False
+
 
 class TestSubscriber:
     @patch.object(SubscriberClient, "create_subscription")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 import concurrent
 import decimal
+from concurrent.futures import TimeoutError
 from unittest.mock import ANY, patch
 
 import pytest

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,11 @@
 import concurrent
 import decimal
-from concurrent.futures import TimeoutError
 from unittest.mock import ANY, patch
 
 import pytest
 from google.api_core import exceptions
 from google.cloud.pubsub_v1 import SubscriberClient
+from google.cloud.pubsub_v1.exceptions import TimeoutError
 
 
 @pytest.mark.usefixtures("publisher", "time_mock")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -79,6 +79,16 @@ class TestPublisher:
         )
         mock_future.assert_called_once_with(timeout=50)
 
+    @pytest.mark.usefixtures("mock_publish_timeout")
+    def test_runs_post_publish_failure_hook_when_time_out_error(
+        self, publisher, mock_post_process_message_failure
+    ):
+        message = {"foo": "bar"}
+
+        with pytest.raises(TimeoutError):
+            publisher.publish(topic="order-cancelled", data=message, myattr="hello")
+            mock_post_process_message_failure.assert_called_once()
+
 
 class TestSubscriber:
     @patch.object(SubscriberClient, "create_subscription")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -99,6 +99,7 @@ class TestPublisher:
         message = {"foo": "bar"}
         e = TimeoutError()
         mock_future.result.side_effect = e
+
         with pytest.raises(TimeoutError):
             publisher.publish(
                 topic="order-cancelled",
@@ -108,7 +109,7 @@ class TestPublisher:
                 raise_exception=True,
             )
 
-    def test_returns_false_when_timeout_error_and_raise_exception_is_false(
+    def test_returns_future_when_timeout_error_and_raise_exception_is_false(
         self, publisher, mock_future
     ):
         message = {"foo": "bar"}
@@ -122,7 +123,8 @@ class TestPublisher:
             blocking=True,
             raise_exception=False,
         )
-        assert result is False
+
+        assert result is mock_future
 
 
 class TestSubscriber:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -86,32 +86,42 @@ class TestPublisher:
         mock_future.result.side_effect = e
 
         with pytest.raises(TimeoutError):
-            publisher.publish(topic="order-cancelled", data=message, myattr="hello",
-                              blocking=True)
+            publisher.publish(
+                topic="order-cancelled", data=message, myattr="hello", blocking=True
+            )
         mock_post_publish_failure.assert_called_once_with(
             "order-cancelled", e, {"foo": "bar"}
         )
 
     def test_raises_when_time_out_error_and_raise_exception_is_true(
-            self, publisher, mock_future):
+        self, publisher, mock_future
+    ):
         message = {"foo": "bar"}
         e = TimeoutError()
         mock_future.result.side_effect = e
         with pytest.raises(TimeoutError):
-            publisher.publish(topic="order-cancelled", data=message, myattr="hello",
-                              blocking=True, raise_exception=True)
+            publisher.publish(
+                topic="order-cancelled",
+                data=message,
+                myattr="hello",
+                blocking=True,
+                raise_exception=True,
+            )
 
     def test_returns_false_when_time_out_error_and_raise_exception_is_false(
-            self, publisher, mock_future):
+        self, publisher, mock_future
+    ):
         message = {"foo": "bar"}
         e = TimeoutError()
         mock_future.result.side_effect = e
 
-        result = publisher.publish(topic="order-cancelled",
-                                   data=message,
-                                   myattr="hello",
-                                   blocking=True,
-                                   raise_exception=False)
+        result = publisher.publish(
+            topic="order-cancelled",
+            data=message,
+            myattr="hello",
+            blocking=True,
+            raise_exception=False,
+        )
         assert result is False
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -82,15 +82,15 @@ class TestPublisher:
         self, mock_future, publisher, mock_post_publish_failure
     ):
         message = {"foo": "bar"}
-        e = TimeoutError()
-        mock_future.result.side_effect = e
+        exception = TimeoutError()
+        mock_future.result.side_effect = exception
 
         with pytest.raises(TimeoutError):
             publisher.publish(
                 topic="order-cancelled", data=message, myattr="hello", blocking=True
             )
         mock_post_publish_failure.assert_called_once_with(
-            "order-cancelled", e, {"foo": "bar"}
+            "order-cancelled", exception, {"foo": "bar"}
         )
 
     def test_raises_when_timeout_error_and_raise_exception_is_true(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -87,10 +87,11 @@ class TestPublisher:
         message = {"foo": "bar"}
 
         with pytest.raises(TimeoutError):
-            publisher.publish(topic="order-cancelled", data=message, myattr="hello")
             mock_post_publish_failure.assert_called_once_with(
                 topic="order-cancelled", exception=TimeoutError, message={"foo": "bar"}
             )
+            publisher.publish(topic="order-cancelled", data=message, myattr="hello",
+                              blocking=True)
 
 
 class TestSubscriber:


### PR DESCRIPTION
### :tophat: What?

Catch `TimeoutError` when publishing while `blocking` and run `post_publish_failure` hook. Also added `raise_exception` parameter.
### :thinking: Why?
Google can raise this error when publishing so it should be handled
### :link: Related issue
#159 
