### PR TITLE
Deprecate GC_CREDENTIALS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 `0.13.0` (TBD)
 * Add documentation for class based subscriptions (#169)
+* Deprecate GC_CREDENTIALS setting
 
 `0.13.dev0` (2020-6-16)
 * Traverse all packages to autodiscover all subs.py modules (#167)

--- a/rele/config.py
+++ b/rele/config.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+import warnings
 
 from google.oauth2 import service_account
 
@@ -55,6 +56,11 @@ class Config:
                 self.gc_credentials_path
             )
         elif self._credentials:
+            warnings.warn(
+                "Usage of GC_CREDENTIALS is deprecated and will be removed in an "
+                "upcoming release. Please use GC_CREDENTIALS_PATH.",
+                DeprecationWarning,
+            )
             return self._credentials
 
         else:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,6 +72,16 @@ class TestConfig:
         assert isinstance(config.credentials, service_account.Credentials)
         assert config.middleware == ["rele.contrib.DjangoDBMiddleware"]
 
+    def test_warns_when_gc_credentials_is_passed(self, project_id, credentials):
+        settings = {
+            "GC_PROJECT_ID": project_id,
+            "GC_CREDENTIALS": credentials,
+        }
+        config = Config(settings)
+
+        with pytest.warns(DeprecationWarning):
+            config.credentials
+
     def test_inits_service_account_creds_when_credential_path_given(self, project_id):
         settings = {
             "GC_PROJECT_ID": project_id,


### PR DESCRIPTION
### :tophat: What?

Deprecate `GC_CREDENTIALS`

### :thinking: Why?

It will be removed in 1.0.0
