### PR TITLE
Remove GC_CREDENTIALS

### DIFF
--- a/docs/api/settings.rst
+++ b/docs/api/settings.rst
@@ -19,9 +19,6 @@ in your Django project's ``settings.py``.
 Example::
 
     RELE = {
-        'GC_CREDENTIALS': service_account.Credentials.from_service_account_file(
-            'rele/settings/dummy-credentials.json'
-        ),
         'GC_CREDENTIALS_PATH': 'rele/settings/dummy-credentials.json',
         'GC_PROJECT_ID': 'dummy-project-id',
         'MIDDLEWARE': [
@@ -36,26 +33,12 @@ Example::
     }
 
 
-``GC_CREDENTIALS``
-------------------
-
-**Optional**
-
-Valid Google Service Account credentials object.
-
-.. note:: This method of authentication will be deprecated in favour of
-    ``GC_CREDENTIALS_PATH`` in the future. Therefore it is recommended to use
-    ``GC_CREDENTIALS_PATH``
-
 ``GC_CREDENTIALS_PATH``
 -----------------------
 
 **Optional**
 
 Path to service account json file with access to PubSub
-
-.. note:: ``GC_CREDENTIALS`` and ``GC_CREDENTIALS_PATH`` are mutually exclusive.
-    If both are provided, ``GC_CREDENTIALS_PATH`` will be used.
 
 ``GC_PROJECT_ID``
 ------------------

--- a/docs/guides/basics.rst
+++ b/docs/guides/basics.rst
@@ -23,7 +23,6 @@ To configure Relé, our settings may look something like:
 .. code:: python
 
     # /settings.py
-    from google.oauth2 import service_account
 
     RELE = {
         'GC_CREDENTIALS_PATH': 'credentials.json',

--- a/docs/guides/basics.rst
+++ b/docs/guides/basics.rst
@@ -26,9 +26,7 @@ To configure Relé, our settings may look something like:
     from google.oauth2 import service_account
 
     RELE = {
-        'GC_CREDENTIALS': service_account.Credentials.from_service_account_file(
-            'credentials.json'
-        ),
+        'GC_CREDENTIALS_PATH': 'credentials.json',
         'GC_PROJECT_ID': 'photo-uploading-app',
     }
 

--- a/docs/guides/django.rst
+++ b/docs/guides/django.rst
@@ -15,7 +15,6 @@ To configure Relé, our settings may look something like:
 
 .. code:: python
 
-    from google.oauth2 import service_account
     RELE = {
         'GC_CREDENTIALS_PATH': 'photo_project/settings/dummy-credentials.json',
         'GC_PROJECT_ID': 'photo-imaging',

--- a/docs/guides/django.rst
+++ b/docs/guides/django.rst
@@ -17,9 +17,7 @@ To configure Relé, our settings may look something like:
 
     from google.oauth2 import service_account
     RELE = {
-        'GC_CREDENTIALS': service_account.Credentials.from_service_account_file(
-            'photo_project/settings/dummy-credentials.json'
-        ),
+        'GC_CREDENTIALS_PATH': 'photo_project/settings/dummy-credentials.json',
         'GC_PROJECT_ID': 'photo-imaging',
         'MIDDLEWARE': [
             'rele.contrib.LoggingMiddleware',

--- a/docs/guides/emulator.rst
+++ b/docs/guides/emulator.rst
@@ -31,7 +31,7 @@ To be able to do that we can follow the steps below:
         'APP_NAME': 'my-awesome-app',
         'SUB_PREFIX': 'test',
         'GC_PROJECT_ID': 'my-awesome-project',
-        'GC_CREDENTIALS': 'my-credentials',
+        'GC_CREDENTIALS_PATH': 'my-credentials',
         'MIDDLEWARE': [
             'rele.contrib.LoggingMiddleware',
             'rele.contrib.DjangoDBMiddleware',

--- a/docs/guides/flask.rst
+++ b/docs/guides/flask.rst
@@ -15,7 +15,6 @@ To configure Relé, our settings may look something like:
 
 .. code:: python
 
-    from google.oauth2 import service_account
     RELE = {
         'GC_CREDENTIALS_PATH': 'photo_project/settings/dummy-credentials.json',
         'GC_PROJECT_ID': 'photo-imaging',

--- a/docs/guides/flask.rst
+++ b/docs/guides/flask.rst
@@ -17,9 +17,7 @@ To configure Relé, our settings may look something like:
 
     from google.oauth2 import service_account
     RELE = {
-        'GC_CREDENTIALS': service_account.Credentials.from_service_account_file(
-            'photo_project/settings/dummy-credentials.json'
-        ),
+        'GC_CREDENTIALS_PATH': 'photo_project/settings/dummy-credentials.json',
         'GC_PROJECT_ID': 'photo-imaging',
         'MIDDLEWARE': [
             'rele.contrib.LoggingMiddleware',

--- a/docs/guides/unrecoverable_middleware.rst
+++ b/docs/guides/unrecoverable_middleware.rst
@@ -17,9 +17,7 @@ First make sure the middleware is included in your Relé config.
     from google.oauth2 import service_account
 
     RELE = {
-        'GC_CREDENTIALS': service_account.Credentials.from_service_account_file(
-            'credentials.json'
-        ),
+        'GC_CREDENTIALSGC_CREDENTIALS_PATH': 'credentials.json',
         'GC_PROJECT_ID': 'photo-uploading-app',
         'MIDDLEWARE': ['rele.contrib.UnrecoverableMiddleWare']
     }

--- a/rele/config.py
+++ b/rele/config.py
@@ -1,6 +1,5 @@
 import importlib
 import os
-import warnings
 
 from google.oauth2 import service_account
 

--- a/rele/config.py
+++ b/rele/config.py
@@ -22,9 +22,7 @@ class Config:
     """
 
     def __init__(self, setting):
-        if (
-            setting.get("GC_PROJECT_ID") is None
-        ):
+        if setting.get("GC_PROJECT_ID") is None:
             credentials, project = get_google_defaults()
 
         self.gc_project_id = setting.get("GC_PROJECT_ID") or project

--- a/rele/config.py
+++ b/rele/config.py
@@ -24,11 +24,9 @@ class Config:
     def __init__(self, setting):
         if (
             setting.get("GC_PROJECT_ID") is None
-            or setting.get("GC_CREDENTIALS") is None
         ):
             credentials, project = get_google_defaults()
 
-        self._credentials = setting.get("GC_CREDENTIALS") or credentials
         self.gc_project_id = setting.get("GC_PROJECT_ID") or project
         self.gc_credentials_path = setting.get("GC_CREDENTIALS_PATH")
         self.app_name = setting.get("APP_NAME")
@@ -55,16 +53,9 @@ class Config:
             return service_account.Credentials.from_service_account_file(
                 self.gc_credentials_path
             )
-        elif self._credentials:
-            warnings.warn(
-                "Usage of GC_CREDENTIALS is deprecated and will be removed in an "
-                "upcoming release. Please use GC_CREDENTIALS_PATH.",
-                DeprecationWarning,
-            )
-            return self._credentials
-
         else:
-            return None
+            credentials, project_id = get_google_defaults()
+            return credentials
 
 
 def setup(setting=None, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from google.cloud.pubsub_v1 import PublisherClient
-from google.oauth2 import service_account
 
 from rele import Publisher
 from rele.client import Subscriber
@@ -19,28 +18,21 @@ def project_id():
 
 
 @pytest.fixture
-def credentials():
-    return service_account.Credentials.from_service_account_file(
-        "tests/dummy-pub-sub-credentials.json"
-    )
-
-
-@pytest.fixture
-def config(credentials, project_id):
+def config(project_id):
     return Config(
         {
             "APP_NAME": "rele",
             "SUB_PREFIX": "rele",
             "GC_PROJECT_ID": project_id,
-            "GC_CREDENTIALS": credentials,
+            "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
             "MIDDLEWARE": ["rele.contrib.LoggingMiddleware"],
         }
     )
 
 
 @pytest.fixture
-def subscriber(project_id, credentials):
-    return Subscriber(project_id, credentials, 60)
+def subscriber(project_id, config):
+    return Subscriber(project_id, config.credentials, 60)
 
 
 @pytest.fixture

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -28,9 +28,7 @@ DATABASES = {"default": {"CONN_MAX_AGE": 0}}
 RELE = {
     "APP_NAME": "test-rele",
     "GC_PROJECT_ID": "SOME-PROJECT-ID",
-    "GC_CREDENTIALS": service_account.Credentials.from_service_account_file(
-        f"{BASE_DIR}/tests/dummy-pub-sub-credentials.json"
-    ),
+    "GC_CREDENTIALS_PATH": f"{BASE_DIR}/tests/dummy-pub-sub-credentials.json",
     "SUB_PREFIX": "rele",
     "MIDDLEWARE": [
         "rele.contrib.LoggingMiddleware",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -4,7 +4,6 @@ import os
 from logging import config as logging_config
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-from google.oauth2 import service_account
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = "Im-so-secret"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,12 +54,12 @@ class TestLoadSubscriptions:
 
 
 class TestConfig:
-    def test_parses_all_keys(self, project_id, credentials, custom_encoder):
+    def test_parses_all_keys(self, project_id, custom_encoder):
         settings = {
             "APP_NAME": "rele",
             "SUB_PREFIX": "rele",
             "GC_PROJECT_ID": project_id,
-            "GC_CREDENTIALS": credentials,
+            "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
             "MIDDLEWARE": ["rele.contrib.DjangoDBMiddleware"],
             "ENCODER": custom_encoder,
         }
@@ -72,16 +72,6 @@ class TestConfig:
         assert isinstance(config.credentials, service_account.Credentials)
         assert config.middleware == ["rele.contrib.DjangoDBMiddleware"]
 
-    def test_warns_when_gc_credentials_is_passed(self, project_id, credentials):
-        settings = {
-            "GC_PROJECT_ID": project_id,
-            "GC_CREDENTIALS": credentials,
-        }
-        config = Config(settings)
-
-        with pytest.warns(DeprecationWarning):
-            config.credentials
-
     def test_inits_service_account_creds_when_credential_path_given(self, project_id):
         settings = {
             "GC_PROJECT_ID": project_id,
@@ -92,20 +82,6 @@ class TestConfig:
 
         assert config.gc_project_id == project_id
         assert isinstance(config.credentials, google.oauth2.service_account.Credentials)
-        assert config.credentials.project_id == "rele-test"
-
-    def test_uses_path_instead_of_gc_credentials_when_both_are_provided(
-        self, credentials
-    ):
-        settings = {
-            "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
-            "GC_CREDENTIALS": credentials,
-        }
-
-        config = Config(settings)
-
-        assert isinstance(config.credentials, google.oauth2.service_account.Credentials)
-        assert config.credentials != credentials
         assert config.credentials.project_id == "rele-test"
 
     @patch.dict(os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": ""})
@@ -130,7 +106,7 @@ class TestConfig:
             + "/dummy-pub-sub-credentials.json"
         },
     )
-    def test_sets_defaults_pulled_from_env(self, monkeypatch, project_id, credentials):
+    def test_sets_defaults_pulled_from_env(self, monkeypatch, project_id):
         settings = {}
 
         config = Config(settings)
@@ -138,6 +114,6 @@ class TestConfig:
         assert config.app_name is None
         assert config.sub_prefix is None
         assert config.gc_project_id == "rele-test"
-        assert config.credentials is not None
+        assert isinstance(config.credentials, google.oauth2.service_account.Credentials)
         assert config.middleware == ["rele.contrib.LoggingMiddleware"]
         assert config.encoder == json.JSONEncoder

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -13,9 +13,7 @@ class TestMiddleware:
 
     @pytest.mark.usefixtures("mock_init_global_publisher")
     @patch("rele.contrib.FlaskMiddleware.setup", autospec=True)
-    def test_setup_fn_is_called_with_kwargs(
-        self, mock_middleware_setup, project_id
-    ):
+    def test_setup_fn_is_called_with_kwargs(self, mock_middleware_setup, project_id):
 
         settings = {
             "GC_PROJECT_ID": project_id,

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -14,12 +14,11 @@ class TestMiddleware:
     @pytest.mark.usefixtures("mock_init_global_publisher")
     @patch("rele.contrib.FlaskMiddleware.setup", autospec=True)
     def test_setup_fn_is_called_with_kwargs(
-        self, mock_middleware_setup, project_id, credentials
+        self, mock_middleware_setup, project_id
     ):
 
         settings = {
             "GC_PROJECT_ID": project_id,
-            "GC_CREDENTIALS": credentials,
             "MIDDLEWARE": ["rele.contrib.FlaskMiddleware"],
         }
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -144,9 +144,7 @@ class TestCreateAndRun:
         with patch("rele.worker.Worker", autospec=True) as p:
             yield p
 
-    def test_waits_forever_when_called_with_config_and_subs(
-        self, config, mock_worker
-    ):
+    def test_waits_forever_when_called_with_config_and_subs(self, config, mock_worker):
         subscriptions = (sub_stub,)
         create_and_run(subscriptions, config)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -16,12 +16,12 @@ def sub_stub(data, **kwargs):
 
 
 @pytest.fixture
-def worker(project_id, credentials, config):
+def worker(config):
     subscriptions = (sub_stub,)
     return Worker(
         subscriptions,
-        project_id,
-        credentials,
+        config.gc_project_id,
+        config.credentials,
         default_ack_deadline=60,
         threads_per_subscription=10,
     )
@@ -99,14 +99,14 @@ class TestWorker:
 
     @pytest.mark.usefixtures("mock_create_subscription")
     def test_creates_subscription_with_custom_ack_deadline_from_environment(
-        self, project_id, credentials
+        self, config
     ):
         subscriptions = (sub_stub,)
         custom_ack_deadline = 234
         worker = Worker(
             subscriptions,
-            project_id,
-            credentials,
+            config.gc_project_id,
+            config.credentials,
             custom_ack_deadline,
             threads_per_subscription=10,
         )
@@ -145,10 +145,10 @@ class TestCreateAndRun:
             yield p
 
     def test_waits_forever_when_called_with_config_and_subs(
-        self, config, mock_worker, credentials
+        self, config, mock_worker
     ):
         subscriptions = (sub_stub,)
         create_and_run(subscriptions, config)
 
-        mock_worker.assert_called_with(subscriptions, "rele-test", credentials, 60, 2)
+        mock_worker.assert_called_with(subscriptions, "rele-test", ANY, 60, 2)
         mock_worker.return_value.run_forever.assert_called_once_with()


### PR DESCRIPTION
### :tophat: What?

Remove deprecated GC_CREDENTIALS setting

### :thinking: Why?

It was deprecated in #173 and is scheduled for removal by 1.0.0

### :link: Related issue

#173 #170 
