### PR TITLE
Deprecate GC_PROJECT_ID setting

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -5,14 +5,20 @@ API Reference
 
 .. _ client
 
-Client
-------
+Clients
+-------
 
 .. autoclass:: rele.client.Publisher
    :members:
 
 
 .. _ publish
+
+.. autoclass:: rele.client.Subscriber
+   :members:
+
+
+.. _ subscriber
 
 Publish
 -------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -46,9 +46,12 @@ Path to service account json file with access to PubSub
 ``GC_PROJECT_ID``
 ------------------
 
-**Optional**
+**Deprecated**
 
 Valid Google Project ID
+
+.. warning:: This will be removed in an upcoming release in favor of getting
+    project_id from the credentials.
 
 
 ``MIDDLEWARE``

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -40,12 +40,16 @@ Example::
 
 Path to service account json file with access to PubSub
 
+
+.. _settings_project_id:
+
 ``GC_PROJECT_ID``
 ------------------
 
-**Required**
+**Optional**
 
 Valid Google Project ID
+
 
 ``MIDDLEWARE``
 ------------------

--- a/rele/client.py
+++ b/rele/client.py
@@ -32,6 +32,7 @@ class Subscriber:
     For convenience, this class wraps the creation and consumption of a topic
     subscription.
 
+    :param gc_project_id: string :ref:`_settings_project_id` .
     :param credentials: obj :meth:`~rele.config.Config.credentials`.
     :param default_ack_deadline: int Ack Deadline defined in settings
     """

--- a/rele/client.py
+++ b/rele/client.py
@@ -32,19 +32,18 @@ class Subscriber:
     For convenience, this class wraps the creation and consumption of a topic
     subscription.
 
-    :param gc_project_id: string Google Cloud Project ID.
     :param credentials: string Google Cloud Credentials.
     :param default_ack_deadline: int Ack Deadline defined in settings
     """
 
-    def __init__(self, gc_project_id=None, credentials=None, default_ack_deadline=None):
+    def __init__(self, credentials=None, default_ack_deadline=None):
 
-        if gc_project_id is None or credentials is None:
+        if credentials is None:
             creds, project = get_google_defaults()
 
-        self._gc_project_id = gc_project_id or project
         self._ack_deadline = default_ack_deadline or DEFAULT_ACK_DEADLINE
         _credentials = credentials or creds
+        self._gc_project_id = _credentials.project_id or project
 
         if USE_EMULATOR:
             self._client = pubsub_v1.SubscriberClient()

--- a/rele/client.py
+++ b/rele/client.py
@@ -32,7 +32,7 @@ class Subscriber:
     For convenience, this class wraps the creation and consumption of a topic
     subscription.
 
-    :param credentials: string Google Cloud Credentials.
+    :param credentials: obj :meth:`~rele.config.Config.credentials`.
     :param default_ack_deadline: int Ack Deadline defined in settings
     """
 
@@ -76,7 +76,7 @@ class Subscriber:
 
         :param subscription_name: str Subscription name
         :param callback: Function which act on a topic message
-        :param scheduler: `Thread pool-based scheduler.<https://googleapis.dev/python/pubsub/latest/subscriber/api/scheduler.html?highlight=threadscheduler#google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler>`_  # noqa
+        :param scheduler: `Thread pool-based scheduler. <https://googleapis.dev/python/pubsub/latest/subscriber/api/scheduler.html?highlight=threadscheduler#google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler>`_  # noqa
         :return: `Future <https://googleapis.github.io/google-cloud-python/latest/pubsub/subscriber/api/futures.html>`_  # noqa
         """
         subscription_path = self._client.subscription_path(

--- a/rele/client.py
+++ b/rele/client.py
@@ -36,8 +36,8 @@ class Subscriber:
     :param default_ack_deadline: int Ack Deadline defined in settings
     """
 
-    def __init__(self, credentials, default_ack_deadline=None):
-        self._gc_project_id = credentials.project_id
+    def __init__(self, gc_project_id, credentials, default_ack_deadline=None):
+        self._gc_project_id = gc_project_id
         self._ack_deadline = default_ack_deadline or DEFAULT_ACK_DEADLINE
 
         if USE_EMULATOR:

--- a/rele/client.py
+++ b/rele/client.py
@@ -36,19 +36,14 @@ class Subscriber:
     :param default_ack_deadline: int Ack Deadline defined in settings
     """
 
-    def __init__(self, credentials=None, default_ack_deadline=None):
-
-        if credentials is None:
-            creds, project = get_google_defaults()
-
+    def __init__(self, credentials, default_ack_deadline=None):
+        self._gc_project_id = credentials.project_id
         self._ack_deadline = default_ack_deadline or DEFAULT_ACK_DEADLINE
-        _credentials = credentials or creds
-        self._gc_project_id = _credentials.project_id or project
 
         if USE_EMULATOR:
             self._client = pubsub_v1.SubscriberClient()
         else:
-            self._client = pubsub_v1.SubscriberClient(credentials=_credentials)
+            self._client = pubsub_v1.SubscriberClient(credentials=credentials)
 
     def create_subscription(self, subscription, topic):
         """Handles creating the subscription when it does not exists.

--- a/rele/client.py
+++ b/rele/client.py
@@ -32,7 +32,7 @@ class Subscriber:
     For convenience, this class wraps the creation and consumption of a topic
     subscription.
 
-    :param gc_project_id: string :ref:`_settings_project_id` .
+    :param gc_project_id: str :ref:`settings_project_id` .
     :param credentials: obj :meth:`~rele.config.Config.credentials`.
     :param default_ack_deadline: int Ack Deadline defined in settings
     """

--- a/rele/config.py
+++ b/rele/config.py
@@ -58,7 +58,8 @@ class Config:
     def gc_project_id(self):
         if self._project_id:
             warnings.warn(
-                "GC_PROJECT_ID is deprecated in a future release.", DeprecationWarning)
+                "GC_PROJECT_ID is deprecated in a future release.", DeprecationWarning
+            )
             return self._project_id
         elif self.credentials:
             return self.credentials.project_id

--- a/rele/config.py
+++ b/rele/config.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+import warnings
 
 from google.oauth2 import service_account
 
@@ -56,6 +57,8 @@ class Config:
     @property
     def gc_project_id(self):
         if self._project_id:
+            warnings.warn(
+                "GC_PROJECT_ID is deprecated in a future release.", DeprecationWarning)
             return self._project_id
         elif self.credentials:
             return self.credentials.project_id

--- a/rele/config.py
+++ b/rele/config.py
@@ -21,10 +21,7 @@ class Config:
     """
 
     def __init__(self, setting):
-        if setting.get("GC_PROJECT_ID") is None:
-            credentials, project = get_google_defaults()
-
-        self.gc_project_id = setting.get("GC_PROJECT_ID") or project
+        self._project_id = setting.get("GC_PROJECT_ID")
         self.gc_credentials_path = setting.get("GC_CREDENTIALS_PATH")
         self.app_name = setting.get("APP_NAME")
         self.sub_prefix = setting.get("SUB_PREFIX")
@@ -37,6 +34,7 @@ class Config:
         self.publisher_timeout = setting.get("PUBLISHER_TIMEOUT", 3.0)
         self.threads_per_subscription = setting.get("THREADS_PER_SUBSCRIPTION", 2)
         self.filter_by = setting.get("FILTER_SUBS_BY")
+        self._credentials = None
 
     @property
     def encoder(self):
@@ -47,12 +45,22 @@ class Config:
     @property
     def credentials(self):
         if self.gc_credentials_path:
-            return service_account.Credentials.from_service_account_file(
+            self._credentials = service_account.Credentials.from_service_account_file(
                 self.gc_credentials_path
             )
         else:
-            credentials, project_id = get_google_defaults()
-            return credentials
+            credentials, __ = get_google_defaults()
+            self._credentials = credentials
+        return self._credentials
+
+    @property
+    def gc_project_id(self):
+        if self._project_id:
+            return self._project_id
+        elif self.credentials:
+            return self.credentials.project_id
+        else:
+            return None
 
 
 def setup(setting=None, **kwargs):

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -25,11 +25,12 @@ class Worker:
     def __init__(
         self,
         subscriptions,
+        gc_project_id=None,
         credentials=None,
         default_ack_deadline=None,
         threads_per_subscription=None,
     ):
-        self._subscriber = Subscriber(credentials, default_ack_deadline)
+        self._subscriber = Subscriber(gc_project_id, credentials, default_ack_deadline)
         self._futures = []
         self._subscriptions = subscriptions
         self.threads_per_subscription = threads_per_subscription
@@ -126,7 +127,11 @@ def create_and_run(subs, config):
     for sub in subs:
         print(f"  {sub}")
     worker = Worker(
-        subs, config.credentials, config.ack_deadline, config.threads_per_subscription,
+        subs,
+        config.gc_project_id,
+        config.credentials,
+        config.ack_deadline,
+        config.threads_per_subscription,
     )
 
     signal.signal(signal.SIGINT, signal.SIG_IGN)

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -25,7 +25,6 @@ class Worker:
     def __init__(
         self,
         subscriptions,
-        gc_project_id=None,
         credentials=None,
         default_ack_deadline=None,
         threads_per_subscription=None,
@@ -128,7 +127,6 @@ def create_and_run(subs, config):
         print(f"  {sub}")
     worker = Worker(
         subs,
-        config.gc_project_id,
         config.credentials,
         config.ack_deadline,
         config.threads_per_subscription,

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -126,10 +126,7 @@ def create_and_run(subs, config):
     for sub in subs:
         print(f"  {sub}")
     worker = Worker(
-        subs,
-        config.credentials,
-        config.ack_deadline,
-        config.threads_per_subscription,
+        subs, config.credentials, config.ack_deadline, config.threads_per_subscription,
     )
 
     signal.signal(signal.SIGINT, signal.SIG_IGN)

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -30,7 +30,7 @@ class Worker:
         default_ack_deadline=None,
         threads_per_subscription=None,
     ):
-        self._subscriber = Subscriber(gc_project_id, credentials, default_ack_deadline)
+        self._subscriber = Subscriber(credentials, default_ack_deadline)
         self._futures = []
         self._subscriptions = subscriptions
         self.threads_per_subscription = threads_per_subscription

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -9,7 +9,7 @@ from rele import Worker
 class TestRunReleCommand:
     @pytest.fixture(autouse=True)
     def worker_wait_forever(self):
-        with patch.object(Worker, "_wait_forever", return_value=None) as p:
+        with patch.object(Worker, "_wait_forever", return_value=None, autospec=True) as p:
             yield p
 
     @pytest.fixture
@@ -20,7 +20,7 @@ class TestRunReleCommand:
     def test_calls_worker_start_and_setup_when_runrele(self, mock_worker):
         call_command("runrele")
 
-        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 2)
+        mock_worker.assert_called_with([], ANY, 60, 2)
         mock_worker.return_value.run_forever.assert_called_once_with()
 
     def test_prints_warning_when_conn_max_age_not_set_to_zero(
@@ -35,5 +35,5 @@ class TestRunReleCommand:
             "This may result in slots for database connections to "
             "be exhausted." in err
         )
-        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 2)
+        mock_worker.assert_called_with([], ANY, 60, 2)
         mock_worker.return_value.run_forever.assert_called_once_with()

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -9,7 +9,9 @@ from rele import Worker
 class TestRunReleCommand:
     @pytest.fixture(autouse=True)
     def worker_wait_forever(self):
-        with patch.object(Worker, "_wait_forever", return_value=None, autospec=True) as p:
+        with patch.object(
+            Worker, "_wait_forever", return_value=None, autospec=True
+        ) as p:
             yield p
 
     @pytest.fixture

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -22,7 +22,7 @@ class TestRunReleCommand:
     def test_calls_worker_start_and_setup_when_runrele(self, mock_worker):
         call_command("runrele")
 
-        mock_worker.assert_called_with([], ANY, 60, 2)
+        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 2)
         mock_worker.return_value.run_forever.assert_called_once_with()
 
     def test_prints_warning_when_conn_max_age_not_set_to_zero(
@@ -37,5 +37,5 @@ class TestRunReleCommand:
             "This may result in slots for database connections to "
             "be exhausted." in err
         )
-        mock_worker.assert_called_with([], ANY, 60, 2)
+        mock_worker.assert_called_with([], "SOME-PROJECT-ID", ANY, 60, 2)
         mock_worker.return_value.run_forever.assert_called_once_with()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,6 @@ def config(project_id):
         {
             "APP_NAME": "rele",
             "SUB_PREFIX": "rele",
-            "GC_PROJECT_ID": project_id,
             "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
             "MIDDLEWARE": ["rele.contrib.LoggingMiddleware"],
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def config(project_id):
 
 @pytest.fixture
 def subscriber(project_id, config):
-    return Subscriber(project_id, config.credentials, 60)
+    return Subscriber(config.credentials, 60)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def config(project_id):
 
 @pytest.fixture
 def subscriber(project_id, config):
-    return Subscriber(config.credentials, 60)
+    return Subscriber(config.gc_project_id, config.credentials, 60)
 
 
 @pytest.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -140,6 +140,7 @@ class TestSubscriber:
         _mocked_client.assert_called_once_with(
             ack_deadline_seconds=60, name=expected_subscription, topic=expected_topic,
         )
+        assert subscriber._gc_project_id == 'rele-test'
 
     @patch.object(SubscriberClient, "create_subscription")
     def test_creates_subscription_with_custom_ack_deadline_when_provided(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -140,7 +140,7 @@ class TestSubscriber:
         _mocked_client.assert_called_once_with(
             ack_deadline_seconds=60, name=expected_subscription, topic=expected_topic,
         )
-        assert subscriber._gc_project_id == 'rele-test'
+        assert subscriber._gc_project_id == "rele-test"
 
     @patch.object(SubscriberClient, "create_subscription")
     def test_creates_subscription_with_custom_ack_deadline_when_provided(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,6 +84,17 @@ class TestConfig:
         assert isinstance(config.credentials, google.oauth2.service_account.Credentials)
         assert config.credentials.project_id == "rele-test"
 
+    def test_uses_project_id_from_creds_when_no_project_id_given(self):
+        settings = {
+            "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
+        }
+
+        config = Config(settings)
+
+        assert isinstance(config.credentials, google.oauth2.service_account.Credentials)
+        assert config.credentials.project_id == "rele-test"
+        assert config.gc_project_id == 'rele-test'
+
     @patch.dict(os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": ""})
     def test_sets_defaults(self):
         settings = {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,7 +93,7 @@ class TestConfig:
 
         assert isinstance(config.credentials, google.oauth2.service_account.Credentials)
         assert config.credentials.project_id == "rele-test"
-        assert config.gc_project_id == 'rele-test'
+        assert config.gc_project_id == "rele-test"
 
     @patch.dict(os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": ""})
     def test_sets_defaults(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,7 +58,6 @@ class TestConfig:
         settings = {
             "APP_NAME": "rele",
             "SUB_PREFIX": "rele",
-            "GC_PROJECT_ID": project_id,
             "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
             "MIDDLEWARE": ["rele.contrib.DjangoDBMiddleware"],
             "ENCODER": custom_encoder,
@@ -83,6 +82,17 @@ class TestConfig:
         assert config.gc_project_id == project_id
         assert isinstance(config.credentials, google.oauth2.service_account.Credentials)
         assert config.credentials.project_id == "rele-test"
+
+    def test_warns_when_gc_project_id_given(self, project_id):
+        settings = {
+            "GC_PROJECT_ID": project_id,
+            "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
+        }
+
+        config = Config(settings)
+
+        with pytest.warns(DeprecationWarning):
+            assert config.gc_project_id == project_id
 
     def test_uses_project_id_from_creds_when_no_project_id_given(self):
         settings = {

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -20,7 +20,6 @@ def worker(config):
     subscriptions = (sub_stub,)
     return Worker(
         subscriptions,
-        config.gc_project_id,
         config.credentials,
         default_ack_deadline=60,
         threads_per_subscription=10,
@@ -105,7 +104,6 @@ class TestWorker:
         custom_ack_deadline = 234
         worker = Worker(
             subscriptions,
-            config.gc_project_id,
             config.credentials,
             custom_ack_deadline,
             threads_per_subscription=10,
@@ -113,6 +111,7 @@ class TestWorker:
         worker.setup()
 
         assert worker._subscriber._ack_deadline == custom_ack_deadline
+        assert worker._subscriber._gc_project_id == "rele-test"
 
     @patch.dict(
         os.environ,
@@ -148,5 +147,5 @@ class TestCreateAndRun:
         subscriptions = (sub_stub,)
         create_and_run(subscriptions, config)
 
-        mock_worker.assert_called_with(subscriptions, "rele-test", ANY, 60, 2)
+        mock_worker.assert_called_with(subscriptions, ANY, 60, 2)
         mock_worker.return_value.run_forever.assert_called_once_with()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -113,24 +113,6 @@ class TestWorker:
         assert worker._subscriber._ack_deadline == custom_ack_deadline
         assert worker._subscriber._gc_project_id == "rele-test"
 
-    @patch.dict(
-        os.environ,
-        {
-            "GOOGLE_APPLICATION_CREDENTIALS": os.path.dirname(
-                os.path.realpath(__file__)
-            )
-            + "/dummy-pub-sub-credentials.json"
-        },
-    )
-    @pytest.mark.usefixtures("mock_create_subscription")
-    def test_creates_without_config(self):
-        subscriptions = (sub_stub,)
-        worker = Worker(subscriptions)
-        worker.setup()
-
-        assert worker._subscriber._ack_deadline == 60
-        assert worker._subscriber._gc_project_id == "rele-test"
-
 
 class TestCreateAndRun:
     @pytest.fixture(autouse=True)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -103,6 +103,7 @@ class TestWorker:
         custom_ack_deadline = 234
         worker = Worker(
             subscriptions,
+            config.gc_project_id,
             config.credentials,
             custom_ack_deadline,
             threads_per_subscription=10,
@@ -128,5 +129,5 @@ class TestCreateAndRun:
         subscriptions = (sub_stub,)
         create_and_run(subscriptions, config)
 
-        mock_worker.assert_called_with(subscriptions, ANY, 60, 2)
+        mock_worker.assert_called_with(subscriptions, "rele-test", ANY, 60, 2)
         mock_worker.return_value.run_forever.assert_called_once_with()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,4 +1,3 @@
-import os
 from concurrent import futures
 from unittest.mock import ANY, patch
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -19,6 +19,7 @@ def worker(config):
     subscriptions = (sub_stub,)
     return Worker(
         subscriptions,
+        config.gc_project_id,
         config.credentials,
         default_ack_deadline=60,
         threads_per_subscription=10,


### PR DESCRIPTION
### :tophat: What?

Deprecate GC_PROJECT_ID. I was even thinking about removing it. Since we can fallback to using the credentials, the removal shouldnt be a breaking change. What do you all think? 

### :thinking: Why?

Simpler setup or a user. Less settings == less hassle

### :link: Related issue

#176 
