### PR TITLE
0.14.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.14.0 (2020-8-5)
+-------------------
+* BREAKING CHANGE: Remove GC_CREDENTIALS (#174)
+* Add changelog to the docs site (#179)
+* Catch TimeoutError and run post_publish_failure when blocking (#172)
+* Deprecate GC_PROJECT_ID setting (#178)
+
 0.13.0 (2020-7-9)
 -------------------
 * Add documentation for class based subscriptions (#169)

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 default_app_config = "rele.apps.ReleConfig"
 
 from .client import Publisher, Subscriber  # noqa


### PR DESCRIPTION
### :tophat: What?

Bump version to 0.14.0

### :thinking: Why?

We have quite a number of things to be deployed before 1.0.0 

### :link: Related issue

#175 
