### PR TITLE
Fix #180: Raise error when the config loads a repeated subscription

### DIFF
--- a/rele/config.py
+++ b/rele/config.py
@@ -103,9 +103,11 @@ def load_subscriptions_from_paths(sub_module_paths, sub_prefix=None, filter_by=N
                 subscription.set_filters(filter_by)
 
             if subscription.name in subscriptions:
+                found_subscription = subscriptions[subscription.name]
                 raise RuntimeError(
                     f"Duplicated subscription found: {subscription.name}. Handled by "
-                    f"{sub_module_path}.{attr_name} and some more."
+                    f"{subscription._func.__module__}.{subscription._func.__name__} and "
+                    f"{found_subscription._func.__module__}.{found_subscription._func.__name__}."
                 )
 
             subscriptions[subscription.name] = subscription

--- a/rele/config.py
+++ b/rele/config.py
@@ -87,7 +87,7 @@ def subscription_from_attribute(attribute):
 
 def load_subscriptions_from_paths(sub_module_paths, sub_prefix=None, filter_by=None):
 
-    subscriptions = []
+    subscriptions = {}
     for sub_module_path in sub_module_paths:
         sub_module = importlib.import_module(sub_module_path)
         for attr_name in dir(sub_module):
@@ -102,5 +102,10 @@ def load_subscriptions_from_paths(sub_module_paths, sub_prefix=None, filter_by=N
             if filter_by and not subscription.filter_by:
                 subscription.set_filters(filter_by)
 
-            subscriptions.append(subscription)
-    return subscriptions
+            if subscription.name in subscriptions:
+                raise RuntimeError(
+                    f"Duplicated subscription found: {subscription.name}."
+                )
+
+            subscriptions[subscription.name] = subscription
+    return list(subscriptions.values())

--- a/rele/config.py
+++ b/rele/config.py
@@ -104,7 +104,8 @@ def load_subscriptions_from_paths(sub_module_paths, sub_prefix=None, filter_by=N
 
             if subscription.name in subscriptions:
                 raise RuntimeError(
-                    f"Duplicated subscription found: {subscription.name}."
+                    f"Duplicated subscription found: {subscription.name}. Handled by "
+                    f"{sub_module_path}.{attr_name} and some more."
                 )
 
             subscriptions[subscription.name] = subscription

--- a/rele/config.py
+++ b/rele/config.py
@@ -105,9 +105,9 @@ def load_subscriptions_from_paths(sub_module_paths, sub_prefix=None, filter_by=N
             if subscription.name in subscriptions:
                 found_subscription = subscriptions[subscription.name]
                 raise RuntimeError(
-                    f"Duplicated subscription found: {subscription.name}. Handled by "
+                    f"Duplicate subscription name found: {subscription.name}. Subs "
                     f"{subscription._func.__module__}.{subscription._func.__name__} and "
-                    f"{found_subscription._func.__module__}.{found_subscription._func.__name__}."
+                    f"{found_subscription._func.__module__}.{found_subscription._func.__name__} collide."
                 )
 
             subscriptions[subscription.name] = subscription

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,7 +56,7 @@ class TestLoadSubscriptions:
         assert (
             str(excinfo.value)
             == "Duplicated subscription found: rele-another-cool-topic. "
-            "Handled by tests.more_subs.subs.another_sub_stub and some more."
+            "Handled by tests.more_subs.subs.another_sub_stub and tests.test_config.another_sub_stub."
         )
 
     def test_returns_sub_value_when_filtered_value_applied(self, subscriptions):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,8 +55,8 @@ class TestLoadSubscriptions:
 
         assert (
             str(excinfo.value)
-            == "Duplicated subscription found: rele-another-cool-topic. "
-            "Handled by tests.more_subs.subs.another_sub_stub and tests.test_config.another_sub_stub."
+            == "Duplicate subscription name found: rele-another-cool-topic. Subs "
+            "tests.more_subs.subs.another_sub_stub and tests.test_config.another_sub_stub collide."
         )
 
     def test_returns_sub_value_when_filtered_value_applied(self, subscriptions):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,7 +55,8 @@ class TestLoadSubscriptions:
 
         assert (
             str(excinfo.value)
-            == "Duplicated subscription found: rele-another-cool-topic."
+            == "Duplicated subscription found: rele-another-cool-topic. "
+            "Handled by tests.more_subs.subs.another_sub_stub and some more."
         )
 
     def test_returns_sub_value_when_filtered_value_applied(self, subscriptions):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,11 @@ def sub_stub(data, **kwargs):
     return data["id"]
 
 
+@sub(topic="another-cool-topic", prefix="rele")
+def another_sub_stub(data, **kwargs):
+    return data["id"]
+
+
 class TestLoadSubscriptions:
     @pytest.fixture
     def subscriptions(self):
@@ -25,8 +30,8 @@ class TestLoadSubscriptions:
         )
 
     def test_load_subscriptions_in_a_module(self, subscriptions):
-        assert len(subscriptions) == 1
-        func_sub = subscriptions[0]
+        assert len(subscriptions) == 2
+        func_sub = subscriptions[-1]
         assert isinstance(func_sub, Subscription)
         assert func_sub.name == "rele-test-topic"
         assert func_sub({"id": 4}, lang="en") == 4
@@ -43,6 +48,15 @@ class TestLoadSubscriptions:
         assert isinstance(klass_sub, Subscription)
         assert klass_sub.name == "test-alternative-cool-topic"
         assert klass_sub({"id": 4}, lang="en") == 4
+
+    def test_raises_error_when_subscription_is_duplicated(self):
+        with pytest.raises(RuntimeError) as excinfo:
+            load_subscriptions_from_paths(["tests.test_config", "tests.more_subs.subs"])
+
+        assert (
+            str(excinfo.value)
+            == "Duplicated subscription found: rele-another-cool-topic."
+        )
 
     def test_returns_sub_value_when_filtered_value_applied(self, subscriptions):
 


### PR DESCRIPTION
### :tophat: What?

Raise error when the config loads a repeated subscription

### :thinking: Why?

The issue describes it well:
https://github.com/mercadona/rele/issues/180

Fix #180
