### PR TITLE
Discover and load settings when publishing

### DIFF
--- a/rele/publishing.py
+++ b/rele/publishing.py
@@ -1,3 +1,5 @@
+from rele import config, discover
+
 from .client import Publisher
 
 _publisher = None
@@ -41,5 +43,10 @@ def publish(topic, data, **kwargs):
     :return: None
     """
     if not _publisher:
-        raise ValueError("init_global_publisher must be called first.")
+        settings, _ = discover.sub_modules()
+        if not hasattr(settings, "RELE"):
+            raise ValueError("Config setup not called and settings module not found.")
+
+        config.setup(settings.RELE)
+
     _publisher.publish(topic, data, **kwargs)

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -1,12 +1,28 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from tests import settings
 
 from rele import Publisher, publishing
 
 
 class TestPublish:
-    def test_raises_when_global_publisher_does_not_exist(self):
+    @patch("rele.publishing.Publisher", autospec=True)
+    def test_instantiates_publisher_and_publishes_when_does_not_exist(
+        self, mock_publisher
+    ):
+        with patch("rele.publishing.discover") as mock_discover:
+            mock_discover.sub_modules.return_value = settings, []
+
+            message = {"foo": "bar"}
+            publishing.publish(topic="order-cancelled", data=message, myattr="hello")
+
+            mock_publisher.return_value.publish.assert_called_with(
+                "order-cancelled", {"foo": "bar"}, myattr="hello"
+            )
+
+    def test_raises_error_when_publisher_does_not_exists_and_settings_not_found(self):
+        publishing._publisher = None
         message = {"foo": "bar"}
 
         with pytest.raises(ValueError):
@@ -18,6 +34,7 @@ class TestInitGlobalPublisher:
     def test_creates_global_publisher_when_published_called(
         self, mock_publisher, config
     ):
+        publishing._publisher = None
         mock_publisher.return_value = MagicMock(spec=Publisher)
         publishing.init_global_publisher(config)
         message = {"foo": "bar"}


### PR DESCRIPTION
### :tophat: What?

Implement discovering and setup of settings when publishing without calling to `config.setup()`

### :thinking: Why?

To avoid the boilerplate in simple setups.

### :link: Related issue
Fix #177 
