### PR TITLE
Add validations to the sub decorator

### DIFF
--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -191,7 +191,7 @@ def sub(topic, prefix=None, suffix=None, filter_by=None):
 
     def decorator(func):
         args_spec = getfullargspec(func)
-        if len(args_spec.args) != 1:
+        if len(args_spec.args) < 2:
             raise RuntimeError(
                 f"Subscription function {func.__module__}.{func.__name__} is not valid. "
                 "The function must have one argument. "

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -192,10 +192,10 @@ def sub(topic, prefix=None, suffix=None, filter_by=None):
 
     def decorator(func):
         args_spec = getfullargspec(func)
-        if len(args_spec.args) != 1:
+        if len(args_spec.args) != 1 or not args_spec.varkw:
             raise RuntimeError(
                 f"Subscription function {func.__module__}.{func.__name__} is not valid. "
-                "The function must have one argument. "
+                "The function must have one argument and accept keyword arguments."
             )
 
         if getmodule(func).__name__.split(".")[-1] != "subs":

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -331,15 +331,21 @@ class TestCallback:
 
 class TestDecorator:
     def test_returns_subscription_when_callback_valid(self):
-        subscription = sub(topic="topic", prefix="rele")(lambda data: None)
+        subscription = sub(topic="topic", prefix="rele")(lambda data, **kwargs: None)
         assert isinstance(subscription, Subscription)
 
     def test_raises_error_when_function_signature_is_not_valid(self):
         with pytest.raises(RuntimeError):
             sub(topic="topic", prefix="rele")(lambda: None)
 
+        with pytest.raises(RuntimeError):
+            sub(topic="topic", prefix="rele")(lambda data: None)
+
+        with pytest.raises(RuntimeError):
+            sub(topic="topic", prefix="rele")(lambda data, value=None: None)
+
     def test_logs_warning_when_function_not_in_subs_module(self, caplog):
-        sub(topic="topic", prefix="rele")(lambda data: None)
+        sub(topic="topic", prefix="rele")(lambda data, **kwargs: None)
         assert (
             "Subscription function tests.test_subscription.<lambda> is outside a subs "
             "module that will not be discovered." in caplog.text

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -323,8 +323,9 @@ class TestDecorator:
         sub(topic="topic", prefix="rele")(lambda data: None)
         assert (
             "Subscription function tests.test_subscription.<lambda> is outside a subs "
+            "module that will not be discovered." in caplog.text
         )
-        "module that will not be discovered." in caplog.text
+        
 
     def test_raises_error_when_filter_by_is_not_valid(self, caplog):
         sub(topic="topic", prefix="rele", filter_by=lambda x: True)(lambda data: None)

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -311,7 +311,7 @@ class TestCallback:
 
 
 class TestDecorator:
-    def test_returns_susbscription_when_function_valid(self):
+    def test_returns_subscription_when_callback_valid(self):
         subscription = sub(topic="topic", prefix="rele")(lambda data: None)
         assert isinstance(subscription, Subscription)
 

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -308,3 +308,32 @@ class TestCallback:
 
         assert res == 123
         assert mock_close_old_connections.call_count == 2
+
+
+class TestDecorator:
+    def test_returns_susbscription_when_function_valid(self):
+        subscription = sub(topic="topic", prefix="rele")(lambda data: None)
+        assert isinstance(subscription, Subscription)
+
+    def test_raises_error_when_function_signature_is_not_valid(self):
+        with pytest.raises(RuntimeError):
+            sub(topic="topic", prefix="rele")(lambda: None)
+
+    def test_logs_warning_when_function_not_in_subs_module(self, caplog):
+        sub(topic="topic", prefix="rele")(lambda data: None)
+        assert (
+            "Subscription function tests.test_subscription.<lambda> is outside a subs "
+        )
+        "module that will not be discovered." in caplog.text
+
+    def test_raises_error_when_filter_by_is_not_valid(self, caplog):
+        sub(topic="topic", prefix="rele", filter_by=lambda x: True)(lambda data: None)
+        sub(topic="topic", prefix="rele", filter_by=((lambda x: True),))(
+            lambda data: None
+        )
+
+        with pytest.raises(ValueError):
+            sub(topic="topic", prefix="rele", filter_by=1)(lambda data: None)
+
+        with pytest.raises(ValueError):
+            sub(topic="topic", prefix="rele", filter_by=(1,))(lambda data: None)

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -111,6 +111,25 @@ class TestSubscription:
 
         assert response is None
 
+    def test_raises_error_when_filter_by_is_not_valid(self, caplog):
+        Subscription(
+            func=lambda x: None, topic="topic", prefix="rele", filter_by=lambda x: True
+        )
+        Subscription(
+            func=lambda x: None,
+            topic="topic",
+            prefix="rele",
+            filter_by=((lambda x: True),),
+        )
+
+        with pytest.raises(ValueError):
+            Subscription(func=lambda x: None, topic="topic", prefix="rele", filter_by=1)
+
+        with pytest.raises(ValueError):
+            Subscription(
+                func=lambda x: None, topic="topic", prefix="rele", filter_by=(1,)
+            )
+
 
 class TestCallback:
     @pytest.fixture(autouse=True)
@@ -325,16 +344,3 @@ class TestDecorator:
             "Subscription function tests.test_subscription.<lambda> is outside a subs "
             "module that will not be discovered." in caplog.text
         )
-        
-
-    def test_raises_error_when_filter_by_is_not_valid(self, caplog):
-        sub(topic="topic", prefix="rele", filter_by=lambda x: True)(lambda data: None)
-        sub(topic="topic", prefix="rele", filter_by=((lambda x: True),))(
-            lambda data: None
-        )
-
-        with pytest.raises(ValueError):
-            sub(topic="topic", prefix="rele", filter_by=1)(lambda data: None)
-
-        with pytest.raises(ValueError):
-            sub(topic="topic", prefix="rele", filter_by=(1,))(lambda data: None)


### PR DESCRIPTION
### :tophat: What?

Add validations to the sub decorator. 
Validate the signature of the subscription function to check if it has the correct number of arguments.
Validate the `filter_by` parameter to check if it is a callable or a iterable of callables as defined in the docstring.
Log a warning if the subscription function it's outside a discoverable module to alert the user that that susbcription will not be created.

### :thinking: Why?

Improvements suggested in https://github.com/mercadona/rele/issues/186

The use of the `wraps` decorator in the sub decorator is not useful as the decorator returns a Subscription instance and not a function so the expected behaviour of keep the `__name__` and `__doc__` is lost. If someone knows the way to acomplish it please leave a comment.

### :link: Related issue

Fix #186 
