### PR TITLE
Add new post_publish_hook and deprecate the old one

### DIFF
--- a/rele/client.py
+++ b/rele/client.py
@@ -167,6 +167,9 @@ class Publisher:
             if raise_exception:
                 raise e
         else:
+            run_middleware_hook("post_publish_success", topic)
+
+            # DEPRECATED
             run_middleware_hook("post_publish", topic)
 
         return future

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -62,7 +62,7 @@ class BaseMiddleware(metaclass=WarnDeprecatedHooks):
         """
 
     def post_publish_success(self, topic):
-        """DEPRECATED: Called after Publisher sends message.
+        """Called after Publisher sends message.
         :param topic:
         """
 

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -1,4 +1,5 @@
 import importlib
+import warnings
 
 _middlewares = []
 
@@ -24,7 +25,20 @@ def run_middleware_hook(hook_name, *args, **kwargs):
         getattr(middleware, hook_name)(*args, **kwargs)
 
 
-class BaseMiddleware:
+class WarnDeprecatedHooks(type):
+    def __new__(cls, *args, **kwargs):
+        x = super().__new__(cls, *args, **kwargs)
+        if hasattr(x, "post_publish"):
+            warnings.warn(
+                "The post_publish hook in the middleware is deprecated "
+                "and will be removed in future versions. Please substitute it with "
+                "the post_publish_success hook instead.",
+                DeprecationWarning,
+            )
+        return x
+
+
+class BaseMiddleware(metaclass=WarnDeprecatedHooks):
     """Base class for middleware.  The default implementations
     for all hooks are no-ops and subclasses may implement whatever
     subset of hooks they like.
@@ -43,7 +57,12 @@ class BaseMiddleware:
         """
 
     def post_publish(self, topic):
-        """Called after Publisher sends message.
+        """DEPRECATED: Called after Publisher sends message.
+        :param topic:
+        """
+
+    def post_publish_success(self, topic):
+        """DEPRECATED: Called after Publisher sends message.
         :param topic:
         """
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 import rele
+from rele.middleware import BaseMiddleware
 
 
 class TestMiddleware:
@@ -23,3 +24,11 @@ class TestMiddleware:
         rele.setup(settings, foo="bar")
         assert mock_middleware_setup.called
         assert mock_middleware_setup.call_args_list[0][-1] == {"foo": "bar"}
+
+    def test_warns_about_deprecated_hooks(self, caplog):
+
+        with pytest.warns(DeprecationWarning):
+
+            class TestMiddleware(BaseMiddleware):
+                def post_publish(self, topic):
+                    pass

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -25,7 +25,7 @@ class TestMiddleware:
         assert mock_middleware_setup.called
         assert mock_middleware_setup.call_args_list[0][-1] == {"foo": "bar"}
 
-    def test_warns_about_deprecated_hooks(self, caplog):
+    def test_warns_about_deprecated_hooks(self):
 
         with pytest.warns(DeprecationWarning):
 


### PR DESCRIPTION
### :tophat: What?

Added new post_publish_hook and deprecate the old one

### :thinking: Why?

To have a more consistent interface as suggested in https://github.com/mercadona/rele/issues/181

### :link: Related issue

Fix #181
