### PR TITLE
Support Python 3.9-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
 
 install:
   - make install-requirements


### PR DESCRIPTION
### :tophat: What?

Support a Python 3.9 variant
Travis does not yet have Python 3.9 stable as an option in the build. 

### :thinking: Why?

We want to be as up to date as possible
