### PR TITLE
Do not define default_app_config, it's deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
 language: python
 python:
   - "3.6"
-  - "3.7"
   - "3.8"
   - "3.9-dev"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ language: python
 python:
   - "3.6"
   - "3.8"
-  - "3.9-dev"
+  - "3.9"
 
 install:
   - make install-requirements

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     pass
 else:
-    if django.__version__ < '3.2':
+    if django.__version__ < "3.2":
         default_app_config = "rele.apps.ReleConfig"
 
 from .client import Publisher, Subscriber  # noqa

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,5 +1,4 @@
 __version__ = "1.1.0"
-default_app_config = "rele.apps.ReleConfig"
 
 from .client import Publisher, Subscriber  # noqa
 from .config import setup  # noqa

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,5 +1,13 @@
 __version__ = "1.1.0"
 
+try:
+    import django
+except ImportError:
+    pass
+else:
+    if django.__version__ < '3.2':
+        default_app_config = "rele.apps.ReleConfig"
+
 from .client import Publisher, Subscriber  # noqa
 from .config import setup  # noqa
 from .publishing import publish  # noqa

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -2,7 +2,7 @@ import json
 import logging
 import time
 from collections.abc import Iterable
-from inspect import getfullargspec, getmodule, signature
+from inspect import getfullargspec, getmodule
 
 from .middleware import run_middleware_hook
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,11 +8,11 @@ exclude=
     build,
     dist
 ignore=D1,D401
-max-line-length=88
+max-line-length=90
 max-complexity=10
 
 [isort]
-line_length=88
+line_length=90
 default_section=THIRDPARTY
 known_first_party=rele
 multi_line_output=3

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ setup(
         "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
+        "Framework :: Django :: 3.1",
+        "Framework :: Django :: 3.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
@@ -58,6 +60,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     entry_points={"console_scripts": ["rele-cli=rele.__main__:main"]},
 )

--- a/tests/commands/test_showsubscriptions.py
+++ b/tests/commands/test_showsubscriptions.py
@@ -45,10 +45,13 @@ class TestShowSubscriptions:
 
         mock_discover_subs.assert_called_once()
         captured = capfd.readouterr()
-        assert captured.out == """Topic                Subscriber(s)         Sub
+        assert (
+            captured.out
+            == """Topic                Subscriber(s)         Sub
 -------------------  --------------------  ----------------------------
 photo-updated        photo-updated         sub_process_landscape_photos
 published-time-type  published-time-type   sub_published_time_type
 some-cool-topic      rele-some-cool-topic  sub_stub
 some-fancy-topic     some-fancy-topic      sub_fancy_stub
 """
+        )

--- a/tests/commands/test_showsubscriptions.py
+++ b/tests/commands/test_showsubscriptions.py
@@ -45,13 +45,10 @@ class TestShowSubscriptions:
 
         mock_discover_subs.assert_called_once()
         captured = capfd.readouterr()
-        assert (
-            captured.out
-            == """Topic                Subscriber(s)         Sub
+        assert captured.out == """Topic                Subscriber(s)         Sub
 -------------------  --------------------  ----------------------------
 photo-updated        photo-updated         sub_process_landscape_photos
 published-time-type  published-time-type   sub_published_time_type
 some-cool-topic      rele-some-cool-topic  sub_stub
 some-fancy-topic     some-fancy-topic      sub_fancy_stub
 """
-        )


### PR DESCRIPTION
### :tophat: What?

Stop defining a `default_app_config` for Django.

### :thinking: Why?

It's been [deprecated in Django 3.2](https://docs.djangoproject.com/en/3.2/ref/applications/#for-application-authors)

