### PR TITLE
Do not implement deprecated middlewares in the base class

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,8 +51,9 @@ html_theme = "alabaster"
 html_theme_options = {
     "font_family": "Heebo",
     "logo_name": False,
-    "code_font_family": ('"SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,'
-                         ' monospace'),
+    "code_font_family": (
+        '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,' " monospace"
+    ),
     "code_font_size": "0.8em",
     "show_related": False,
     "fixed_sidebar": False,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(".."))
 
-import rele
+import rele  # noqa
 
 # -- Project information -----------------------------------------------------
 
@@ -51,7 +51,8 @@ html_theme = "alabaster"
 html_theme_options = {
     "font_family": "Heebo",
     "logo_name": False,
-    "code_font_family": '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace',
+    "code_font_family": ('"SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,'
+                         ' monospace'),
     "code_font_size": "0.8em",
     "show_related": False,
     "fixed_sidebar": False,
@@ -69,6 +70,7 @@ master_doc = "index"
 html_static_path = ["_static"]
 
 html_sidebars = {"**": ["sidebar.html", "navigation.html", "searchbox.html"]}
+
 
 # Setup function
 def setup(app):

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -4,7 +4,7 @@ import warnings
 _middlewares = []
 
 default_middleware = ["rele.contrib.LoggingMiddleware"]
-DEPRECATED_HOOKS = ['post_publish']
+DEPRECATED_HOOKS = ["post_publish"]
 
 
 def register_middleware(config, **kwargs):

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -3,8 +3,8 @@ import warnings
 
 _middlewares = []
 
-
 default_middleware = ["rele.contrib.LoggingMiddleware"]
+DEPRECATED_HOOKS = ['post_publish']
 
 
 def register_middleware(config, **kwargs):
@@ -22,19 +22,21 @@ def register_middleware(config, **kwargs):
 
 def run_middleware_hook(hook_name, *args, **kwargs):
     for middleware in _middlewares:
-        getattr(middleware, hook_name)(*args, **kwargs)
+        if hook_name not in DEPRECATED_HOOKS or hasattr(middleware, hook_name):
+            getattr(middleware, hook_name)(*args, **kwargs)
 
 
 class WarnDeprecatedHooks(type):
     def __new__(cls, *args, **kwargs):
         x = super().__new__(cls, *args, **kwargs)
-        if hasattr(x, "post_publish"):
-            warnings.warn(
-                "The post_publish hook in the middleware is deprecated "
-                "and will be removed in future versions. Please substitute it with "
-                "the post_publish_success hook instead.",
-                DeprecationWarning,
-            )
+        for deprecated_hook in DEPRECATED_HOOKS:
+            if hasattr(x, deprecated_hook):
+                warnings.warn(
+                    "The post_publish hook in the middleware is deprecated "
+                    "and will be removed in future versions. Please substitute it with "
+                    "the post_publish_success hook instead.",
+                    DeprecationWarning,
+                )
         return x
 
 
@@ -54,11 +56,6 @@ class BaseMiddleware(metaclass=WarnDeprecatedHooks):
         :param topic:
         :param data:
         :param attrs:
-        """
-
-    def post_publish(self, topic):
-        """DEPRECATED: Called after Publisher sends message.
-        :param topic:
         """
 
     def post_publish_success(self, topic):


### PR DESCRIPTION


### :tophat: What?

This silences the post_publish warning in the case where you do not implement it

### :thinking: Why?

No need to raise a warning for something a middleware author has not done!

