### PR TITLE
Log post publish success

### DIFF
--- a/rele/client.py
+++ b/rele/client.py
@@ -167,7 +167,7 @@ class Publisher:
             if raise_exception:
                 raise e
         else:
-            run_middleware_hook("post_publish_success", topic)
+            run_middleware_hook("post_publish_success", topic, data, attrs)
 
             # DEPRECATED
             run_middleware_hook("post_publish", topic)

--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -37,8 +37,20 @@ class LoggingMiddleware(BaseMiddleware):
         return result
 
     def pre_publish(self, topic, data, attrs):
-        self._logger.info(
+        self._logger.debug(
             f"Publishing to {topic}",
+            extra={
+                "pubsub_publisher_attrs": attrs,
+                "metrics": {
+                    "name": "publications",
+                    "data": {"agent": self._app_name, "topic": topic},
+                },
+            },
+        )
+
+    def post_publish_success(self, topic, data, attrs):
+        self._logger.info(
+            f"Successfully published to {topic}",
             extra={
                 "pubsub_publisher_attrs": attrs,
                 "metrics": {

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -58,9 +58,11 @@ class BaseMiddleware(metaclass=WarnDeprecatedHooks):
         :param attrs:
         """
 
-    def post_publish_success(self, topic):
-        """Called after Publisher sends message.
+    def post_publish_success(self, topic, data, attrs):
+        """Called after Publisher succesfully sends message.
         :param topic:
+        :param data:
+        :param attrs:
         """
 
     def post_publish_failure(self, topic, exception, message):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 import concurrent
 import decimal
+import logging
 from unittest.mock import ANY, patch
 
 import pytest
@@ -26,8 +27,8 @@ class TestPublisher:
         )
 
     def test_save_log_when_published_called(self, published_at, publisher, caplog):
+        caplog.set_level(logging.DEBUG)
         message = {"foo": "bar"}
-
         publisher.publish(topic="order-cancelled", data=message, myattr="hello")
 
         log = caplog.records[0]


### PR DESCRIPTION
### :tophat: What?

- Log post publish success
- Log pre publish at debug level to not be too noisy

### :thinking: Why?

It's more clear to log on success or failure after publishing a message. The existing pre publish may be misleading if the process doing the publishing is killed.

### :link: Related issue

Fix #201 
