### PR TITLE
Automatic topic creation

### DIFF
--- a/rele/client.py
+++ b/rele/client.py
@@ -68,7 +68,7 @@ class Subscriber:
                     f"Creating {topic_path}..."
                 )
                 topic = self._create_topic(topic_path)
-                logger.warning(f"{topic.name} created.")
+                logger.info(f"Topic {topic.name} created.")
                 self._create_subscription(subscription_path, topic_path)
 
     def _create_topic(self, topic_path):

--- a/rele/client.py
+++ b/rele/client.py
@@ -41,7 +41,7 @@ class Subscriber:
         self._gc_project_id = gc_project_id
         self._ack_deadline = default_ack_deadline or DEFAULT_ACK_DEADLINE
         self.credentials = credentials if not USE_EMULATOR else None
-        self._subscriber_client = pubsub_v1.SubscriberClient(credentials=credentials)
+        self._client = pubsub_v1.SubscriberClient(credentials=credentials)
 
     def create_subscription(self, subscription, topic):
         """Handles creating the subscription when it does not exists.
@@ -54,10 +54,10 @@ class Subscriber:
         :param subscription: str Subscription name
         :param topic: str Topic name to subscribe
         """
-        subscription_path = self._subscriber_client.subscription_path(
+        subscription_path = self._client.subscription_path(
             self._gc_project_id, subscription
         )
-        topic_path = self._subscriber_client.topic_path(self._gc_project_id, topic)
+        topic_path = self._client.topic_path(self._gc_project_id, topic)
 
         with suppress(exceptions.AlreadyExists):
             try:
@@ -76,7 +76,7 @@ class Subscriber:
         return publisher_client.create_topic(request={"name": topic_path})
 
     def _create_subscription(self, name, topic):
-        self._subscriber_client.create_subscription(
+        self._client.create_subscription(
             name=name,
             topic=topic,
             ack_deadline_seconds=self._ack_deadline,
@@ -90,10 +90,10 @@ class Subscriber:
         :param scheduler: `Thread pool-based scheduler. <https://googleapis.dev/python/pubsub/latest/subscriber/api/scheduler.html?highlight=threadscheduler#google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler>`_  # noqa
         :return: `Future <https://googleapis.github.io/google-cloud-python/latest/pubsub/subscriber/api/futures.html>`_  # noqa
         """
-        subscription_path = self._subscriber_client.subscription_path(
+        subscription_path = self._client.subscription_path(
             self._gc_project_id, subscription_name
         )
-        return self._subscriber_client.subscribe(
+        return self._client.subscribe(
             subscription_path, callback=callback, scheduler=scheduler
         )
 

--- a/rele/client.py
+++ b/rele/client.py
@@ -43,14 +43,12 @@ class Subscriber:
 
         if USE_EMULATOR:
             self._subscriber_client = pubsub_v1.SubscriberClient()
-            self._publisher_subscriber_client = pubsub_v1.PublisherClient()
+            self._publisher_client = pubsub_v1.PublisherClient()
         else:
             self._subscriber_client = pubsub_v1.SubscriberClient(
                 credentials=credentials
             )
-            self._publisher_subscriber_client = pubsub_v1.PublisherClient(
-                credentials=credentials
-            )
+            self._publisher_client = pubsub_v1.PublisherClient(credentials=credentials)
 
     def create_subscription(self, subscription, topic):
         """Handles creating the subscription when it does not exists.
@@ -72,14 +70,14 @@ class Subscriber:
             try:
                 self._create_subscription(subscription_path, topic_path)
             except exceptions.NotFound:
-                logger.info(
+                logger.warning(
                     "Cannot subscribe to a topic that does not exist."
-                    "Creating topic..."
+                    f"Creating {topic_path}..."
                 )
-                topic = self._publisher_subscriber_client.create_topic(
+                topic = self._publisher_client.create_topic(
                     request={"name": topic_path}
                 )
-                logger.info(f"Topic {topic.name} created.")
+                logger.warning(f"{topic.name} created.")
                 self._create_subscription(subscription_path, topic_path)
 
     def _create_subscription(self, name, topic):

--- a/rele/client.py
+++ b/rele/client.py
@@ -70,11 +70,7 @@ class Subscriber:
 
         with suppress(exceptions.AlreadyExists):
             try:
-                self._subscriber_client.create_subscription(
-                    name=subscription_path,
-                    topic=topic_path,
-                    ack_deadline_seconds=self._ack_deadline,
-                )
+                self._create_subscription(subscription_path, topic_path)
             except exceptions.NotFound:
                 logger.info(
                     "Cannot subscribe to a topic that does not exist."
@@ -84,6 +80,14 @@ class Subscriber:
                     request={"name": topic_path}
                 )
                 logger.info(f"Topic {topic.name} created.")
+                self._create_subscription(subscription_path, topic_path)
+
+    def _create_subscription(self, name, topic):
+        self._subscriber_client.create_subscription(
+            name=name,
+            topic=topic,
+            ack_deadline_seconds=self._ack_deadline,
+        )
 
     def consume(self, subscription_name, callback, scheduler):
         """Begin listening to topic from the SubscriberClient.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -194,7 +194,7 @@ class TestSubscriber:
     @patch.object(
         SubscriberClient,
         "create_subscription",
-        side_effect=exceptions.NotFound("Subscription topic does not exist"),
+        side_effect=[exceptions.NotFound("Subscription topic does not exist"), True],
     )
     def test_create_topic_when_subscription_topic_does_not_exist(
         self, _mocked_client, project_id, subscriber, mock_create_topic
@@ -203,5 +203,5 @@ class TestSubscriber:
             subscription="test-topic", topic=f"{project_id}-test-topic"
         )
 
-        _mocked_client.assert_called()
+        assert _mocked_client.call_count == 2
         mock_create_topic.assert_called()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -196,7 +196,7 @@ class TestSubscriber:
         "create_subscription",
         side_effect=[exceptions.NotFound("Subscription topic does not exist"), True],
     )
-    def test_create_topic_when_subscription_topic_does_not_exist(
+    def test_creates_topic_when_subscription_topic_does_not_exist(
         self, _mocked_client, project_id, subscriber, mock_create_topic
     ):
         subscriber.create_subscription(
@@ -204,4 +204,6 @@ class TestSubscriber:
         )
 
         assert _mocked_client.call_count == 2
-        mock_create_topic.assert_called()
+        mock_create_topic.assert_called_with(
+            request={"name": f"projects/rele-test/topics/{project_id}-test-topic"}
+        )


### PR DESCRIPTION
### :tophat: What?

Automatic topic creation when topic does not exist in PubSub.

### :thinking: Why?

When we trying to subscribe to a topic that doesn't exist, there is a crash. In this feature, we create the topic automatically if this does not exist and then retry to initialize the subscription.

PubSub credentials must have editor role.

### :link: Related issue

None
