### PR TITLE
Add filter expressions to subscriptions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ html_sidebars = {"**": ["sidebar.html", "navigation.html", "searchbox.html"]}
 
 # Setup function
 def setup(app):
-    app.add_stylesheet("style.css")
+    app.add_css_file("style.css")
 
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/guides/filters.rst
+++ b/docs/guides/filters.rst
@@ -2,8 +2,9 @@ Filtering Messages
 ==================
 
 Filter can be used to execute a subscription with specific parameters.
-There's two types of filters, global or passing a filter_by parameter in the
-subscription.
+There's three types of filters, global, by passing a filter_by parameter in the
+subscription (this applies the filter locally) or by passing a filter_expression
+parameter in the subscription (this applies the filter on pubsub).
 
 
 `filter_by` parameter
@@ -25,6 +26,26 @@ is passed as parameter ``filter_by`` in the subscription.
     def sub_process_landscape_photos(data, **kwargs):
         print(f'Received a photo of type {kwargs.get("type")}')
 
+
+`filter_expression` parameter
+_____________________________
+
+This filter is an expression that is applied to the subscription creation. This filter
+expression is applied by pubsub before passing the message to the subscriber. More info
+about filter expressions `here <https://cloud.google.com/pubsub/docs/filtering#filtering_syntax>`_.
+
+.. note::
+   Filter expressions are only applied on the subscription creation, they are not updated
+   if changed if you do not recreate the subscription on pubsub.
+
+.. code:: python
+
+    # This subscription is going to be called if in the kwargs
+    # has a key type with value landscape
+
+    @sub(topic='photo-updated', filter_expression='attributes.type = "landscape"')
+    def sub_process_landscape_photos(data, **kwargs):
+        print(f'Received a photo of type {kwargs.get("type")}')
 
 
 Global Filter

--- a/docs/guides/filters.rst
+++ b/docs/guides/filters.rst
@@ -3,7 +3,7 @@ Filtering Messages
 
 Filter can be used to execute a subscription with specific parameters.
 There's three types of filters, global, by passing a filter_by parameter in the
-subscription (this applies the filter locally) or by passing a filter_expression
+subscription (this applies the filter locally) or by passing a backend_filter_by
 parameter in the subscription (this applies the filter on pubsub).
 
 
@@ -27,7 +27,7 @@ is passed as parameter ``filter_by`` in the subscription.
         print(f'Received a photo of type {kwargs.get("type")}')
 
 
-`filter_expression` parameter
+`backend_filter_by` parameter
 _____________________________
 
 This filter is an expression that is applied to the subscription creation. This filter
@@ -43,7 +43,7 @@ about filter expressions `here <https://cloud.google.com/pubsub/docs/filtering#f
     # This subscription is going to be called if in the kwargs
     # has a key type with value landscape
 
-    @sub(topic='photo-updated', filter_expression='attributes.type = "landscape"')
+    @sub(topic='photo-updated', backend_filter_by='attributes.type = "landscape"')
     def sub_process_landscape_photos(data, **kwargs):
         print(f'Received a photo of type {kwargs.get("type")}')
 

--- a/docs/guides/filters.rst
+++ b/docs/guides/filters.rst
@@ -2,7 +2,7 @@ Filtering Messages
 ==================
 
 Filter can be used to execute a subscription with specific parameters.
-There's three types of filters, global, by passing a filter_by parameter in the
+There are three types of filters, global, by passing a filter_by parameter in the
 subscription (this applies the filter locally) or by passing a backend_filter_by
 parameter in the subscription (this applies the filter on pubsub).
 

--- a/rele/client.py
+++ b/rele/client.py
@@ -67,8 +67,8 @@ class Subscriber:
                     "ack_deadline_seconds": self._ack_deadline,
                 }
 
-                if subscription.filter_expression:
-                    request["filter"] = subscription.filter_expression
+                if subscription.backend_filter_by:
+                    request["filter"] = subscription.backend_filter_by
 
                 self._client.create_subscription(request=request)
             except exceptions.NotFound:

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -35,14 +35,14 @@ class Subscription:
     """
 
     def __init__(
-        self, func, topic, prefix="", suffix="", filter_by=None, filter_expression=None
+        self, func, topic, prefix="", suffix="", filter_by=None, backend_filter_by=None
     ):
         self._func = func
         self.topic = topic
         self._prefix = prefix
         self._suffix = suffix
         self._filters = self._init_filters(filter_by)
-        self.filter_expression = filter_expression
+        self.backend_filter_by = backend_filter_by
 
     def _init_filters(self, filter_by):
         if filter_by and not (
@@ -145,7 +145,7 @@ class Callback:
             run_middleware_hook("post_process_message")
 
 
-def sub(topic, prefix=None, suffix=None, filter_by=None, filter_expression=None):
+def sub(topic, prefix=None, suffix=None, filter_by=None, backend_filter_by=None):
     """Decorator function that makes declaring a PubSub Subscription simple.
 
     The Subscriber returned will automatically create and name

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -34,12 +34,15 @@ class Subscription:
 
     """
 
-    def __init__(self, func, topic, prefix="", suffix="", filter_by=None):
+    def __init__(
+        self, func, topic, prefix="", suffix="", filter_by=None, filter_expression=None
+    ):
         self._func = func
         self.topic = topic
         self._prefix = prefix
         self._suffix = suffix
         self._filters = self._init_filters(filter_by)
+        self.filter_expression = filter_expression
 
     def _init_filters(self, filter_by):
         if filter_by and not (
@@ -142,7 +145,7 @@ class Callback:
             run_middleware_hook("post_process_message")
 
 
-def sub(topic, prefix=None, suffix=None, filter_by=None):
+def sub(topic, prefix=None, suffix=None, filter_by=None, filter_expression=None):
     """Decorator function that makes declaring a PubSub Subscription simple.
 
     The Subscriber returned will automatically create and name

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -42,7 +42,7 @@ class Worker:
         re-created. Therefore, it is idempotent.
         """
         for subscription in self._subscriptions:
-            self._subscriber.create_subscription(subscription.name, subscription.topic)
+            self._subscriber.create_subscription(subscription)
 
     def start(self):
         """Begin consuming all subscriptions.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -190,19 +190,19 @@ class TestSubscriber:
         )
 
     @patch.object(SubscriberClient, "create_subscription")
-    def test_creates_subscription_with_filter_expression_when_provided(
+    def test_creates_subscription_with_backend_filter_by_when_provided(
         self, _mocked_client, project_id, subscriber
     ):
         expected_subscription = (
             f"projects/{project_id}/subscriptions/" f"{project_id}-test-topic"
         )
         expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
-        filter_expression = "attributes:domain"
+        backend_filter_by = "attributes:domain"
         subscriber.create_subscription(
             Subscription(
                 None,
                 topic=f"{project_id}-test-topic",
-                filter_expression=filter_expression,
+                backend_filter_by=backend_filter_by,
             )
         )
 
@@ -211,7 +211,7 @@ class TestSubscriber:
                 "ack_deadline_seconds": 60,
                 "name": expected_subscription,
                 "topic": expected_topic,
-                "filter": filter_expression,
+                "filter": backend_filter_by,
             }
         )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,13 +1,14 @@
 import concurrent
 import decimal
 import logging
-from rele.subscription import Subscription
 from unittest.mock import ANY, patch
 
 import pytest
 from google.api_core import exceptions
 from google.cloud.pubsub_v1 import SubscriberClient
 from google.cloud.pubsub_v1.exceptions import TimeoutError
+
+from rele.subscription import Subscription
 
 
 @pytest.mark.usefixtures("publisher", "time_mock")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -237,11 +237,29 @@ class TestSubscriber:
     def test_creates_topic_when_subscription_topic_does_not_exist(
         self, _mocked_client, project_id, subscriber, mock_create_topic
     ):
+        expected_subscription = (
+            f"projects/{project_id}/subscriptions/" f"{project_id}-test-topic"
+        )
+        expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
+        backend_filter_by = "attributes:domain"
         subscriber.create_subscription(
-            Subscription(None, topic=f"{project_id}-test-topic")
+            Subscription(
+                None,
+                topic=f"{project_id}-test-topic",
+                backend_filter_by=backend_filter_by,
+            )
         )
 
         assert _mocked_client.call_count == 2
         mock_create_topic.assert_called_with(
             request={"name": f"projects/rele-test/topics/{project_id}-test-topic"}
+        )
+
+        _mocked_client.assert_called_with(
+            request={
+                "ack_deadline_seconds": 60,
+                "name": expected_subscription,
+                "topic": expected_topic,
+                "filter": backend_filter_by,
+            }
         )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -53,24 +53,13 @@ class TestWorker:
         assert isinstance(scheduler, ThreadScheduler)
         assert isinstance(scheduler._executor, futures.ThreadPoolExecutor)
 
-    def test_setup_creates_subscription_when_topic_given(
-        self, mock_create_subscription, worker
-    ):
-        worker.setup()
-
-        topic = "some-cool-topic"
-        subscription = "rele-some-cool-topic"
-        mock_create_subscription.assert_called_once_with(subscription, topic)
-
     @patch.object(Worker, "_wait_forever")
     def test_run_sets_up_and_creates_subscriptions_when_called(
         self, mock_wait_forever, mock_consume, mock_create_subscription, worker
     ):
         worker.run_forever()
 
-        topic = "some-cool-topic"
-        subscription = "rele-some-cool-topic"
-        mock_create_subscription.assert_called_once_with(subscription, topic)
+        mock_create_subscription.assert_called_once_with(sub_stub)
         mock_consume.assert_called_once_with(
             subscription_name="rele-some-cool-topic",
             callback=ANY,


### PR DESCRIPTION
### :tophat: What?

Add filter expressions to subscriptions. 

Filter expressions are applied by pubsub before sending the message to a specific subscriber. It's use is defined [here](https://cloud.google.com/pubsub/docs/filtering#filtering_syntax) and it prevents the messages to be sent and filtered by the workers.

### :thinking: Why?

To give support to this pubsub feature.

### :link: Related issue

N/A
