### PR TITLE
Ignore subscriptions without topic defined

### DIFF
--- a/rele/config.py
+++ b/rele/config.py
@@ -94,7 +94,7 @@ def load_subscriptions_from_paths(sub_module_paths, sub_prefix=None, filter_by=N
             attribute = getattr(sub_module, attr_name)
 
             subscription = subscription_from_attribute(attribute)
-            if not subscription:
+            if not subscription or subscription.topic is None:
                 continue
             if sub_prefix and not subscription.prefix:
                 subscription.set_prefix(sub_prefix)

--- a/tests/subs.py
+++ b/tests/subs.py
@@ -17,6 +17,21 @@ class ClassBasedSub(Subscription):
         return data["id"]
 
 
+class GenericClassBasedSub(Subscription):
+    topic = None
+
+    def __init__(self):
+        self._func = self.callback_func
+        super().__init__(self._func, self.topic)
+
+    def callback_func(self, data, **kwargs):
+        return data["id"]
+
+
+class FinalClassBasedSub(GenericClassBasedSub):
+    topic = "final-cool-topic"
+
+
 class CustomException(Exception):
     pass
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,7 +43,7 @@ class TestLoadSubscriptions:
             filter_by=[lambda attrs: attrs.get("lang") == "en"],
         )
 
-        assert len(subscriptions) == 2
+        assert len(subscriptions) == 3
         klass_sub = subscriptions[0]
         assert isinstance(klass_sub, Subscription)
         assert klass_sub.name == "test-alternative-cool-topic"
@@ -58,6 +58,15 @@ class TestLoadSubscriptions:
             == "Duplicate subscription name found: rele-another-cool-topic. Subs "
             "tests.more_subs.subs.another_sub_stub and tests.test_config.another_sub_stub collide."
         )
+
+    def test_does_not_load_subscriptions_without_topic(self):
+        subscriptions = load_subscriptions_from_paths(
+            ["tests.subs"],
+            sub_prefix="test",
+            filter_by=[lambda attrs: attrs.get("lang") == "en"],
+        )
+
+        assert any([sub.topic is not None for sub in subscriptions])
 
     def test_returns_sub_value_when_filtered_value_applied(self, subscriptions):
 


### PR DESCRIPTION
### :tophat: What?

Ignore subscriptions that do not define a topic name.

### :thinking: Why?

Autodiscovery support for class-based Subscriptions (https://github.com/mercadona/rele/issues/161) opens the possibility to create generic classes with shared behavior between subclasses.

```
class GenericClass(Subscription):
    topic = None

    def __init__(self):
        self._func = self.callback_func
        super().__init__(self._func, self.topic)

    def callback_func(self, data, **kwargs):
        return data["type"]

class ClassA(GenericClass):
    topic = "topic-for-A-messages"
    
class ClassB(GenericClass):
    topic = "topic-for-B-messages"
```

`GenericClass` is a subclass of `Subscription` so it will be loaded in the autodiscovery process. However, it does not seem reasonable since it will not be subscribed to any topic.