### PR TITLE
Bump version 1.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.2.0 (2021-12-10)
+-------------------
+* [CHANGED] TimeotError from publisher (#212)
+* Added filter_subs_by setting in documentation (#208)
+* Automatic topic creation (#206)
+* Log post publish success (#204)
+
 1.1.1 (2021-6-28)
 -------------------
 * Do not define default_app_config, it's deprecated (#199)

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 try:
     import django


### PR DESCRIPTION
### :tophat: What?

Prepare 1.2.0 release

### :thinking: Why?

We have some `path` changes and `minor` behavioural changes ready for the bump.

### :link: Related issue

#204 #206 #208 #212 
