### PR TITLE
GC Project Id & Windows support

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,3 +13,4 @@ Thank you to all the contributors to Relé!
 * Craig Mulligan (@hobochild)
 * Daniel Demmel (@daaain)
 * Luis Garcia Cuesta (@luisgc93)
+* Chirag Jain (@chirgjin-les)

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -32,6 +32,14 @@ Example::
         'FILTER_SUBS_BY': boolean_function
     }
 
+``GC_PROJECT_ID``
+------------------
+
+**Optional**
+
+GCP project id to use. If this is not provided then it is inferred via either
+service account's project id or quota project id if using Application Default Credentials (ADC)
+
 
 ``GC_CREDENTIALS_PATH``
 -----------------------

--- a/rele/config.py
+++ b/rele/config.py
@@ -22,6 +22,7 @@ class Config:
     """
 
     def __init__(self, setting):
+        self._gc_project_id = setting.get("GC_PROJECT_ID")
         self.gc_credentials_path = setting.get("GC_CREDENTIALS_PATH")
         self.app_name = setting.get("APP_NAME")
         self.sub_prefix = setting.get("SUB_PREFIX")
@@ -49,13 +50,17 @@ class Config:
                 self.gc_credentials_path
             )
         else:
-            credentials, __ = get_google_defaults()
+            credentials, project_id = get_google_defaults()
             self._credentials = credentials
+            if not self._gc_project_id:
+                self._gc_project_id = project_id
         return self._credentials
 
     @property
     def gc_project_id(self):
-        if self.credentials:
+        if self._gc_project_id:
+            return self._gc_project_id
+        elif self.credentials:
             return self.credentials.project_id
         else:
             return None

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -134,7 +134,13 @@ def create_and_run(subs, config):
         config.threads_per_subscription,
     )
 
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    # to allow killing runrele worker via ctrl+c
+    signal.signal(signal.SIGINT, worker.stop)
     signal.signal(signal.SIGTERM, worker.stop)
-    signal.signal(signal.SIGTSTP, worker.stop)
+    try:
+        signal.signal(signal.SIGTSTP, worker.stop)
+    except:
+        # SIGSTP doesn't exist on windows, so we use SIGBREAK instead
+        signal.signal(signal.SIGBREAK, worker.stop)
+
     worker.run_forever()


### PR DESCRIPTION
### :tophat: What?

This PR adds support for Application Default Credentials (ADC) to rele by allowing users to manually specify their project id. It also allows users to manage which project they want to use when they have access to multiple projects.
It also adds support for windows platforms.

### :thinking: Why?

At our company (@les-transformations), we use workload identity to grant access of pub-sub to applications rather than service account keys which is also a recommended practice by google. So, we added the `GC_PROJECT_ID` setting to support specifying the project id manually as you can't reliably infer that from ADC.

Most of our developers use windows systems so we decided to add support for windows as well

### :link: Related issue

Fixes #214 
