### PR TITLE
Prepare for release v1.4.0

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,3 +14,4 @@ Thank you to all the contributors to Relé!
 * Daniel Demmel (@daaain)
 * Luis Garcia Cuesta (@luisgc93)
 * Chirag Jain (@chirgjin-les)
+* Jordi Chulia (@jorchube)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,9 @@
 Changelog
 =========
 
-1.4.0 (2022-04-04)
+1.4.0 (2022-04-13)
 -------------------
-* [Added] Added a Logging Middleware that does not truncate mesage payload. (#218)
+* [Added] Added a VerboseLoggingMiddleware that does not truncate mesage payload. (#218)
 
 1.3.0 (2022-04-04)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.4.0 (2022-04-04)
+-------------------
+* [Added] Added a Logging Middleware that does not truncate mesage payload. (#218)
+
 1.3.0 (2022-04-04)
 -------------------
 * GC Project Id & Windows support (#215)

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 try:
     import django


### PR DESCRIPTION
### :tophat: What?

Bumped version to v1.4.0 and updated changelog with:

```
1.4.0 (2022-04-13)
-------------------
* [Added] Added a VerboseLoggingMiddleware that does not truncate mesage payload. (#218)
```

