### PR TITLE
[Deleted] Delete `post-publish-message-failure` hook on `VerboseLoggingMiddleware`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /dist/
 /*.egg-info/
 /env/
+/venv/
 MANIFEST
 coverage.*
 docs/_build

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.4.1 (2022-04-19)
+-------------------
+* [Modified] Fixed bug in the post-publish-failure VerboseLoggingMiddleware hook. (#220)
+
 1.4.0 (2022-04-13)
 -------------------
 * [Added] Added a VerboseLoggingMiddleware that does not truncate mesage payload. (#218)

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 try:
     import django

--- a/rele/contrib/verbose_logging_middleware.py
+++ b/rele/contrib/verbose_logging_middleware.py
@@ -11,9 +11,6 @@ class VerboseLoggingMiddleware(LoggingMiddleware):
             subscription, exception, start_time, _VerboseMessage(message)
         )
 
-    def post_publish_failure(self, topic, exception, message):
-        super().post_publish_failure(topic, exception, _VerboseMessage(message))
-
 
 class _VerboseMessage:
     def __init__(self, message):

--- a/tests/contrib/test_verbose_logging_middleware.py
+++ b/tests/contrib/test_verbose_logging_middleware.py
@@ -95,33 +95,3 @@ class TestVerboseLoggingMiddleware:
         message_log = caplog.records[1].subscription_message.__repr__()
 
         assert verbose_message_log == message_log
-
-    def test_message_payload_log_is_not_truncated_on_post_publish_failure(
-        self,
-        verbose_logging_middleware,
-        caplog,
-        long_message_wrapper,
-        expected_message_log,
-    ):
-        verbose_logging_middleware.post_publish_failure(
-            sub_stub, RuntimeError("💩"), long_message_wrapper
-        )
-
-        message_log = caplog.records[0].subscription_message.__repr__()
-
-        assert message_log == expected_message_log
-
-    def test_post_publish_failure_message_payload_format_matches_logging_middleware_format(
-        self, verbose_logging_middleware, logging_middleware, caplog, message_wrapper
-    ):
-        verbose_logging_middleware.post_publish_failure(
-            sub_stub, RuntimeError("💩"), message_wrapper
-        )
-        logging_middleware.post_publish_failure(
-            sub_stub, RuntimeError("💩"), message_wrapper
-        )
-
-        verbose_message_log = caplog.records[0].subscription_message.__repr__()
-        message_log = caplog.records[1].subscription_message.__repr__()
-
-        assert verbose_message_log == message_log


### PR DESCRIPTION
### :tophat: What?

Deleted `post-publish-message-failure` hook on `VerboseLoggingMiddleware`

### :thinking: Why?

The deleted change was originally introduced to have a full non-truncated message log on `post_publish_message_failure`. It turns out that the message passed to the middlewares is **not** the same in the case of `post-publish-message-failure` and `post-process-message-failure` hooks.

`post-process-message-failure` hooks receive the message payload in a wrapper with extra attributes, while `post-publish-message-failure` hooks are given the raw payload, which in turn does not need any additional treatment to have a full log.

