### PR TITLE
[Added] Implement auto restart of the consumption when futures are done or cancelled

### DIFF
--- a/rele/worker.py
+++ b/rele/worker.py
@@ -112,12 +112,8 @@ class Worker:
         logger.info("Consuming subscriptions...")
         while True:
             for subscription, future in self._futures.items():
-                if (
-                    future.cancelled()
-                    or future.done()
-                    or not future._StreamingPullFuture__manager.is_active
-                ):
-                    logger.info(f"Restaring consumption of {subscription.name}.")
+                if future.cancelled() or future.done():
+                    logger.info(f"Restarting consumption of {subscription.name}.")
                     self._boostrap_consumption(subscription)
 
             time.sleep(sleep_interval)

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -31,7 +31,7 @@ class Worker:
         threads_per_subscription=None,
     ):
         self._subscriber = Subscriber(gc_project_id, credentials, default_ack_deadline)
-        self._futures = []
+        self._futures = {}
         self._subscriptions = subscriptions
         self.threads_per_subscription = threads_per_subscription
 
@@ -56,20 +56,7 @@ class Worker:
         """
         run_middleware_hook("pre_worker_start")
         for subscription in self._subscriptions:
-            executor_kwargs = {
-                "thread_name_prefix": "ThreadPoolExecutor-ThreadScheduler"
-            }
-            executor = futures.ThreadPoolExecutor(
-                max_workers=self.threads_per_subscription, **executor_kwargs
-            )
-            scheduler = ThreadScheduler(executor=executor)
-            self._futures.append(
-                self._subscriber.consume(
-                    subscription_name=subscription.name,
-                    callback=Callback(subscription),
-                    scheduler=scheduler,
-                )
-            )
+            self._boostrap_consumption(subscription)
         run_middleware_hook("post_worker_start")
 
     def run_forever(self, sleep_interval=1):
@@ -99,15 +86,40 @@ class Worker:
         :param frame: Needed for `signal.signal <https://docs.python.org/3/library/signal.html#signal.signal>`_  # noqa
         """
         run_middleware_hook("pre_worker_stop", self._subscriptions)
-        for future in self._futures:
+        for future in self._futures.values():
             future.cancel()
 
         run_middleware_hook("post_worker_stop")
         sys.exit(0)
 
+    def _boostrap_consumption(self, subscription):
+        if subscription in self._futures:
+            self._futures[subscription].cancel()
+
+        executor_kwargs = {"thread_name_prefix": "ThreadPoolExecutor-ThreadScheduler"}
+        executor = futures.ThreadPoolExecutor(
+            max_workers=self.threads_per_subscription, **executor_kwargs
+        )
+        scheduler = ThreadScheduler(executor=executor)
+
+        self._futures[subscription] = self._subscriber.consume(
+            subscription_name=subscription.name,
+            callback=Callback(subscription),
+            scheduler=scheduler,
+        )
+
     def _wait_forever(self, sleep_interval):
         logger.info("Consuming subscriptions...")
         while True:
+            for subscription, future in self._futures.items():
+                if (
+                    future.cancelled()
+                    or future.done()
+                    or not future._StreamingPullFuture__manager.is_active
+                ):
+                    logger.info(f"Restaring consumption of {subscription.name}.")
+                    self._boostrap_consumption(subscription)
+
             time.sleep(sleep_interval)
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -144,16 +144,6 @@ class TestRestartConsumer:
 
         assert len(mock_consume.call_args_list) == 2
 
-    def test_restarts_consumption_when_streaming_pull_manager_is_not_active(
-        self, worker, mock_consume
-    ):
-        mock_consume.return_value._StreamingPullFuture__manager._consumer.stop()
-
-        with pytest.raises(ValueError):
-            worker.run_forever()
-
-        assert len(mock_consume.call_args_list) == 2
-
 
 class TestCreateAndRun:
     @pytest.fixture(autouse=True)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -129,7 +129,7 @@ class TestRestartConsumer:
         assert len(mock_consume.call_args_list) == 1
 
     def test_restarts_consumption_when_future_is_cancelled(self, worker, mock_consume):
-        mock_consume.return_value._StreamingPullFuture__cancelled = True
+        mock_consume.return_value.cancel()
 
         with pytest.raises(ValueError):
             worker.run_forever()


### PR DESCRIPTION
### :tophat: What?

Implement auto restart of the consumption when futures are done or cancelled

### :thinking: Why?

In order to auto heal workers when futures are done

