### PR TITLE
fix(logging): subscription_message type was different

### DIFF
--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 
@@ -70,7 +71,7 @@ class LoggingMiddleware(BaseMiddleware):
                     "name": "publications",
                     "data": {"agent": self._app_name, "topic": topic},
                 },
-                "subscription_message": message,
+                "subscription_message": json.dumps(message),
             },
         )
 
@@ -112,7 +113,7 @@ class LoggingMiddleware(BaseMiddleware):
                         subscription, message, "failed", start_time
                     ),
                 },
-                "subscription_message": message,
+                "subscription_message": str(message),
             },
         )
 

--- a/tests/contrib/test_logging_middleware.py
+++ b/tests/contrib/test_logging_middleware.py
@@ -96,4 +96,6 @@ class TestLoggingMiddleware:
         post_publish_failure_message_log = caplog.records[0].subscription_message
         post_process_message_message_log = caplog.records[1].subscription_message
 
-        assert type(post_publish_failure_message_log) == type(post_process_message_message_log)
+        assert type(post_publish_failure_message_log) == type(
+            post_process_message_message_log
+        )

--- a/tests/contrib/test_logging_middleware.py
+++ b/tests/contrib/test_logging_middleware.py
@@ -1,0 +1,99 @@
+import queue
+from unittest.mock import MagicMock
+
+import pytest
+from google.cloud import pubsub_v1
+from tests.subs import sub_stub
+
+from rele.contrib.logging_middleware import LoggingMiddleware
+
+
+@pytest.fixture
+def message_data():
+    return {"foo": "bar"}
+
+
+@pytest.fixture
+def expected_message_data_log():
+    return '{"foo": "bar"}'
+
+
+@pytest.fixture
+def message_wrapper(published_at, publish_time):
+    rele_message = pubsub_v1.types.PubsubMessage(
+        data='{"foo": "bar"}'.encode("utf-8"),
+        attributes={"lang": "es", "published_at": str(published_at)},
+        message_id="1",
+        publish_time=publish_time,
+    )
+
+    message = pubsub_v1.subscriber.message.Message(
+        rele_message._pb,
+        "ack-id",
+        delivery_attempt=1,
+        request_queue=queue.Queue(),
+    )
+    message.ack = MagicMock(autospec=True)
+    return message
+
+
+@pytest.fixture
+def expected_message_log():
+    return 'Message {\n  data: b\'{"foo": "bar"}\'\n  ordering_key: \'\'\n  attributes: {\n    "lang": "es",\n    "published_at": "1560244246.863829"\n  }\n}'
+
+
+class TestLoggingMiddleware:
+    @pytest.fixture
+    def logging_middleware(self, config):
+        logging_middleware = LoggingMiddleware()
+        logging_middleware.setup(config)
+        return logging_middleware
+
+    def test_message_payload_log_is_converted_to_string_on_post_publish_failure(
+        self,
+        logging_middleware,
+        caplog,
+        message_data,
+        expected_message_data_log,
+    ):
+        logging_middleware.post_publish_failure(
+            sub_stub, RuntimeError("💩"), message_data
+        )
+
+        message_log = caplog.records[0].subscription_message
+
+        assert message_log == expected_message_data_log
+
+    def test_message_payload_log_is_converted_to_string_on_post_process_message_failure(
+        self,
+        logging_middleware,
+        caplog,
+        message_wrapper,
+        expected_message_log,
+    ):
+        logging_middleware.post_process_message_failure(
+            sub_stub, RuntimeError("💩"), 1, message_wrapper
+        )
+
+        message_log = caplog.records[0].subscription_message
+
+        assert message_log == expected_message_log
+
+    def test_post_publish_failure_message_payload_format_matches_post_process_message_failure_payload_type(
+        self,
+        logging_middleware,
+        caplog,
+        message_data,
+        message_wrapper,
+    ):
+        logging_middleware.post_publish_failure(
+            sub_stub, RuntimeError("💩"), message_data
+        )
+        logging_middleware.post_process_message_failure(
+            sub_stub, RuntimeError("💩"), 1, message_wrapper
+        )
+
+        post_publish_failure_message_log = caplog.records[0].subscription_message
+        post_process_message_message_log = caplog.records[1].subscription_message
+
+        assert type(post_publish_failure_message_log) == type(post_process_message_message_log)

--- a/tests/contrib/test_verbose_logging_middleware.py
+++ b/tests/contrib/test_verbose_logging_middleware.py
@@ -77,7 +77,7 @@ class TestVerboseLoggingMiddleware:
             sub_stub, RuntimeError("💩"), 1, long_message_wrapper
         )
 
-        message_log = caplog.records[0].subscription_message.__repr__()
+        message_log = caplog.records[0].subscription_message
 
         assert message_log == expected_message_log
 
@@ -91,7 +91,7 @@ class TestVerboseLoggingMiddleware:
             sub_stub, RuntimeError("💩"), 1, message_wrapper
         )
 
-        verbose_message_log = caplog.records[0].subscription_message.__repr__()
-        message_log = caplog.records[1].subscription_message.__repr__()
+        verbose_message_log = caplog.records[0].subscription_message
+        message_log = caplog.records[1].subscription_message
 
         assert verbose_message_log == message_log

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -292,7 +292,7 @@ class TestCallback:
                 },
             },
         }
-        assert failed_log.subscription_message == message_wrapper
+        assert failed_log.subscription_message == str(message_wrapper)
 
     def test_log_acks_called_message_when_not_json_serializable(
         self, caplog, message_wrapper_invalid_json, published_at
@@ -319,7 +319,7 @@ class TestCallback:
                 "attributes": {},
             },
         }
-        assert failed_log.subscription_message == message_wrapper_invalid_json
+        assert failed_log.subscription_message == str(message_wrapper_invalid_json)
 
     def test_published_time_as_message_attribute(self, message_wrapper, caplog):
         callback = Callback(sub_published_time_type)


### PR DESCRIPTION
### :tophat: What?

Unify `subscription_message` data types using always an `String` 


### :thinking: Why?

After call `post_publish_failure` `subscription_message` contains a `dict` with the original data sent
After call `post_process_message_failure()` `subscription_message` contains a `Message` object

So at the end the library publish a `subscription_message` with different data types.

