### PR TITLE
[add] PUBLISHER_BLOCKING setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -126,6 +126,20 @@ Ack deadline for all subscribers in seconds.
     passes, the message is no longer considered outstanding, and Cloud Pub/Sub will attempt
     to redeliver the message.*
 
+.. _settings_publisher_blocking:
+
+``PUBLISHER_BLOCKING``
+---------------------
+
+**Optional**
+
+Default: False
+
+Wait synchronously for the publishing result
+
+`See Google PubSub documentation for more info
+<https://googleapis.dev/python/pubsub/1.1.0/publisher/api/futures.html?highlight=result#google.cloud.pubsub_v1.publisher.futures.Future.result>`_
+
 .. _settings_publisher_timeout:
 
 ``PUBLISHER_TIMEOUT``

--- a/rele/config.py
+++ b/rele/config.py
@@ -4,7 +4,12 @@ import warnings
 
 from google.oauth2 import service_account
 
-from .client import DEFAULT_ACK_DEADLINE, DEFAULT_ENCODER_PATH, get_google_defaults
+from .client import (
+    DEFAULT_ACK_DEADLINE,
+    DEFAULT_BLOCKING,
+    DEFAULT_ENCODER_PATH,
+    get_google_defaults,
+)
 from .middleware import default_middleware, register_middleware
 from .publishing import init_global_publisher
 from .subscription import Subscription
@@ -31,6 +36,7 @@ class Config:
             "ACK_DEADLINE",
             os.environ.get("DEFAULT_ACK_DEADLINE", DEFAULT_ACK_DEADLINE),
         )
+        self.publisher_blocking = setting.get("PUBLISHER_BLOCKING", DEFAULT_BLOCKING)
         self._encoder_path = setting.get("ENCODER_PATH", DEFAULT_ENCODER_PATH)
         self.publisher_timeout = setting.get("PUBLISHER_TIMEOUT", 3.0)
         self.threads_per_subscription = setting.get("THREADS_PER_SUBSCRIPTION", 2)

--- a/rele/publishing.py
+++ b/rele/publishing.py
@@ -13,6 +13,7 @@ def init_global_publisher(config):
             credentials=config.credentials,
             encoder=config.encoder,
             timeout=config.publisher_timeout,
+            blocking=config.publisher_blocking,
         )
     return _publisher
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ known_first_party=rele
 multi_line_output=3
 use_parentheses=true
 skip=docs/
+include_trailing_comma=true
 
 [coverage:run]
 include=*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ def publisher(config, mock_future):
         credentials=config.credentials,
         encoder=config.encoder,
         timeout=config.publisher_timeout,
+        blocking=config.publisher_blocking,
     )
     publisher._client = MagicMock(spec=PublisherClient)
     publisher._client.publish.return_value = mock_future

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -70,6 +70,29 @@ class TestPublisher:
         )
         mock_future.result.assert_called_once_with(timeout=100)
 
+    def test_publishes_data_with_client_timeout_when_blocking_by_default(
+        self, mock_future, publisher
+    ):
+        publisher._timeout = 100.0
+        publisher._blocking = True
+        publisher.publish(topic="order-cancelled", data={"foo": "bar"})
+
+        publisher._client.publish.return_value = mock_future
+        publisher._client.publish.assert_called_with(
+            ANY, b'{"foo": "bar"}', published_at=ANY
+        )
+        mock_future.result.assert_called_once_with(timeout=100)
+
+    def test_publishes_data_non_blocking_by_default(self, mock_future, publisher):
+        publisher._timeout = 100.0
+        publisher.publish(topic="order-cancelled", data={"foo": "bar"})
+
+        publisher._client.publish.return_value = mock_future
+        publisher._client.publish.assert_called_with(
+            ANY, b'{"foo": "bar"}', published_at=ANY
+        )
+        mock_future.result.assert_not_called()
+
     def test_publishes_data_with_client_timeout_when_blocking_and_timeout_specified(
         self, mock_future, publisher
     ):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,6 +76,7 @@ class TestConfig:
             "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
             "MIDDLEWARE": ["rele.contrib.DjangoDBMiddleware"],
             "ENCODER": custom_encoder,
+            "PUBLISHER_BLOCKING": True,
         }
 
         config = Config(settings)
@@ -85,6 +86,7 @@ class TestConfig:
         assert config.gc_project_id == project_id
         assert isinstance(config.credentials, service_account.Credentials)
         assert config.middleware == ["rele.contrib.DjangoDBMiddleware"]
+        assert config.publisher_blocking is True
 
     def test_inits_service_account_creds_when_credential_path_given(self, project_id):
         settings = {
@@ -120,6 +122,7 @@ class TestConfig:
         assert config.credentials is None
         assert config.middleware == ["rele.contrib.LoggingMiddleware"]
         assert config.encoder == json.JSONEncoder
+        assert config.publisher_blocking is False
 
     @patch.dict(
         os.environ,
@@ -141,3 +144,4 @@ class TestConfig:
         assert isinstance(config.credentials, google.oauth2.service_account.Credentials)
         assert config.middleware == ["rele.contrib.LoggingMiddleware"]
         assert config.encoder == json.JSONEncoder
+        assert config.publisher_blocking is False


### PR DESCRIPTION
### :tophat: What?

Allow customization of the default value of the blocking parameter when publishing new messages. By default is `False` for Backward Compatibility preservation.

Adds documentation for this new setting.

### :thinking: Why?

As a developer, I may prefer a `blocking=True` by default so I have full quarantine that my messages have been correctly published.

### :link: Related issue

Fix #202
