### PR TITLE
[fix] Links rendering in FILTER_SUBS_BY

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -159,4 +159,4 @@ library behavior, please set this value to 10.
 **Optional**
 
 Boolean function that applies a global filter on all subscriptions.
-For more information, please see `Filtering Messages section <https://mercadonarele.readthedocs.io/en/latest/guides/filters.html#global-filter>`.
+For more information, please see `Filtering Messages section <https://mercadonarele.readthedocs.io/en/latest/guides/filters.html#global-filter>`_.


### PR DESCRIPTION
### :tophat: What?

Fix link syntax

### :thinking: Why?

This link was not rendered correctly due syntax typo

### :link: Related issue

![image](https://user-images.githubusercontent.com/1301698/197404505-c0b5ac26-5fe9-4594-a27b-93cd18a8f42d.png)

