### PR TITLE
Add exponential backoff

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -29,7 +29,11 @@ Example::
         'ENCODER_PATH': 'rest_framework.utils.encoders.JSONEncoder',
         'ACK_DEADLINE': 120,
         'PUBLISHER_TIMEOUT': 3.0,
-        'FILTER_SUBS_BY': boolean_function
+        'FILTER_SUBS_BY': boolean_function,
+        'DEFAULT_RETRY_POLICY': {
+            'minimum_backoff': 10,
+            'maximum_backoff': 60,
+        }
     }
 
 ``GC_PROJECT_ID``
@@ -174,3 +178,15 @@ library behavior, please set this value to 10.
 
 Boolean function that applies a global filter on all subscriptions.
 For more information, please see `Filtering Messages section <https://mercadonarele.readthedocs.io/en/latest/guides/filters.html#global-filter>`_.
+
+
+``DEFAULT_RETRY_POLICY``
+----------------------------
+
+**Optional**
+
+Dictionary with two keys: `minimum_backoff` and `maximum_backoff`, that specifies in seconds how Pub/Sub retries message delivery for all the subscriptions.
+
+If not set, the default retry policy is applied, meaning a minimum backoff of 10 seconds and a maximum backoff of 60 seconds.
+This generally implies that messages will be retried as soon as possible for healthy subscribers.
+RetryPolicy will be triggered on NACKs or acknowledgement deadline exceeded events for a given message.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -30,10 +30,7 @@ Example::
         'ACK_DEADLINE': 120,
         'PUBLISHER_TIMEOUT': 3.0,
         'FILTER_SUBS_BY': boolean_function,
-        'DEFAULT_RETRY_POLICY': {
-            'minimum_backoff': 10,
-            'maximum_backoff': 60,
-        }
+        'DEFAULT_RETRY_POLICY': RetryPolicy(10, 50),
     }
 
 ``GC_PROJECT_ID``
@@ -185,7 +182,7 @@ For more information, please see `Filtering Messages section <https://mercadonar
 
 **Optional**
 
-Dictionary with two keys: `minimum_backoff` and `maximum_backoff`, that specifies in seconds how Pub/Sub retries message delivery for all the subscriptions.
+A RetryPolicy object which must be instantiated with `minimum_backoff` and `maximum_backoff`, that specifies in seconds how Pub/Sub retries message delivery for all the subscriptions.
 
 If not set, the default retry policy is applied, meaning a minimum backoff of 10 seconds and a maximum backoff of 60 seconds.
 This generally implies that messages will be retried as soon as possible for healthy subscribers.

--- a/rele/client.py
+++ b/rele/client.py
@@ -8,6 +8,8 @@ from contextlib import suppress
 import google.auth
 from google.api_core import exceptions
 from google.cloud import pubsub_v1
+from google.protobuf import duration_pb2
+from google.pubsub_v1 import RetryPolicy
 
 from rele.middleware import run_middleware_hook
 
@@ -38,11 +40,12 @@ class Subscriber:
     :param default_ack_deadline: int Ack Deadline defined in settings
     """
 
-    def __init__(self, gc_project_id, credentials, default_ack_deadline=None):
+    def __init__(self, gc_project_id, credentials, default_ack_deadline=None, default_retry_policy=None):
         self._gc_project_id = gc_project_id
         self._ack_deadline = default_ack_deadline or DEFAULT_ACK_DEADLINE
         self.credentials = credentials if not USE_EMULATOR else None
         self._client = pubsub_v1.SubscriberClient(credentials=credentials)
+        self._retry_policy = default_retry_policy
 
     def create_subscription(self, subscription):
         """Handles creating the subscription when it does not exists.
@@ -52,8 +55,7 @@ class Subscriber:
         have a topic to subscribe to. Which means that the topic must be
         created manually before the worker is started.
 
-        :param subscription: str Subscription name
-        :param topic: str Topic name to subscribe
+        :param subscription: obj :class:`~rele.subscription.Subscription`.
         """
         subscription_path = self._client.subscription_path(
             self._gc_project_id, subscription.name
@@ -85,6 +87,12 @@ class Subscriber:
 
         if subscription.backend_filter_by:
             request["filter"] = subscription.backend_filter_by
+
+        retry_policy = subscription.retry_policy or self._retry_policy
+        if retry_policy:
+            minimum_backoff = duration_pb2.Duration(seconds=retry_policy.get("minimum_backoff"))
+            maximum_backoff = duration_pb2.Duration(seconds=retry_policy.get("maximum_backoff"))
+            request["retry_policy"] = RetryPolicy(minimum_backoff=minimum_backoff, maximum_backoff=maximum_backoff)
 
         self._client.create_subscription(request=request)
 

--- a/rele/client.py
+++ b/rele/client.py
@@ -40,7 +40,13 @@ class Subscriber:
     :param default_ack_deadline: int Ack Deadline defined in settings
     """
 
-    def __init__(self, gc_project_id, credentials, default_ack_deadline=None, default_retry_policy=None):
+    def __init__(
+        self,
+        gc_project_id,
+        credentials,
+        default_ack_deadline=None,
+        default_retry_policy=None,
+    ):
         self._gc_project_id = gc_project_id
         self._ack_deadline = default_ack_deadline or DEFAULT_ACK_DEADLINE
         self.credentials = credentials if not USE_EMULATOR else None
@@ -90,9 +96,15 @@ class Subscriber:
 
         retry_policy = subscription.retry_policy or self._retry_policy
         if retry_policy:
-            minimum_backoff = duration_pb2.Duration(seconds=retry_policy.get("minimum_backoff"))
-            maximum_backoff = duration_pb2.Duration(seconds=retry_policy.get("maximum_backoff"))
-            request["retry_policy"] = RetryPolicy(minimum_backoff=minimum_backoff, maximum_backoff=maximum_backoff)
+            minimum_backoff = duration_pb2.Duration(
+                seconds=retry_policy.get("minimum_backoff")
+            )
+            maximum_backoff = duration_pb2.Duration(
+                seconds=retry_policy.get("maximum_backoff")
+            )
+            request["retry_policy"] = RetryPolicy(
+                minimum_backoff=minimum_backoff, maximum_backoff=maximum_backoff
+            )
 
         self._client.create_subscription(request=request)
 

--- a/rele/config.py
+++ b/rele/config.py
@@ -42,6 +42,7 @@ class Config:
         self.threads_per_subscription = setting.get("THREADS_PER_SUBSCRIPTION", 2)
         self.filter_by = setting.get("FILTER_SUBS_BY")
         self._credentials = None
+        self.retry_policy = setting.get("DEFAULT_RETRY_POLICY")
 
     @property
     def encoder(self):

--- a/rele/retry_policy.py
+++ b/rele/retry_policy.py
@@ -12,8 +12,8 @@ class RetryPolicy:
     :param maximum_backoff: int Accepts values greater than minimum_backoff.
     """
 
-    minimum_backoff: None
-    maximum_backoff: None
+    minimum_backoff: int
+    maximum_backoff: int
 
     def __init__(self, minimum_backoff, maximum_backoff):
         self._guard_against_wrong_parameters(minimum_backoff, maximum_backoff)

--- a/rele/retry_policy.py
+++ b/rele/retry_policy.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class RetryPolicy:
+    minimum_backoff: None
+    maximum_backoff: None
+
+    def __init__(self, minimum_backoff, maximum_backoff):
+        self._guard_against_wrong_parameters(minimum_backoff, maximum_backoff)
+
+        self.minimum_backoff = minimum_backoff
+        self.maximum_backoff = maximum_backoff
+
+    def _guard_against_wrong_parameters(self, minimum_backoff, maximum_backoff):
+        if minimum_backoff == 0:
+            raise ValueError("minimum_backoff must be greater than 0")
+
+        if maximum_backoff == 0:
+            raise ValueError("maximum_backoff must be greater than 0")
+
+        if minimum_backoff > maximum_backoff:
+            raise ValueError("minimum_backoff should be less than maximum_backoff.")

--- a/rele/retry_policy.py
+++ b/rele/retry_policy.py
@@ -3,6 +3,14 @@ from dataclasses import dataclass
 
 @dataclass
 class RetryPolicy:
+    """A RetryPolicy object encapsulates the validation rules.
+
+        Defines retry policy settings and ensures the values are correct.
+        If provided values are wrong, a ValidationError is raised.
+
+        :param minimum_backoff: int Accepts values greater than 0
+        :param maximum_backoff: int Accepts values greater than minimum_backoff.
+        """
     minimum_backoff: None
     maximum_backoff: None
 

--- a/rele/retry_policy.py
+++ b/rele/retry_policy.py
@@ -5,12 +5,13 @@ from dataclasses import dataclass
 class RetryPolicy:
     """A RetryPolicy object encapsulates the validation rules.
 
-        Defines retry policy settings and ensures the values are correct.
-        If provided values are wrong, a ValidationError is raised.
+    Defines retry policy settings and ensures the values are correct.
+    If provided values are wrong, a ValidationError is raised.
 
-        :param minimum_backoff: int Accepts values greater than 0
-        :param maximum_backoff: int Accepts values greater than minimum_backoff.
-        """
+    :param minimum_backoff: int Accepts values greater than 0
+    :param maximum_backoff: int Accepts values greater than minimum_backoff.
+    """
+
     minimum_backoff: None
     maximum_backoff: None
 

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -69,7 +69,6 @@ class Subscription:
 
         return None
 
-
     @property
     def name(self):
         name_parts = [self._prefix, self.topic, self._suffix]

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -211,6 +211,7 @@ def sub(
     :param retry_policy: obj :class:`~rele.retry_policy.RetryPolicy`
     :return: :class:`~rele.subscription.Subscription`
     """
+
     def decorator(func):
         args_spec = getfullargspec(func)
         if len(args_spec.args) != 1 or not args_spec.varkw:

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -45,7 +45,6 @@ class Subscription:
         retry_policy=None,
     ):
         self._validate_filter_by(filter_by)
-        self._validate_retry_policy(retry_policy)
 
         self._func = func
         self.topic = topic
@@ -54,19 +53,6 @@ class Subscription:
         self._filters = self._init_filters(filter_by)
         self.backend_filter_by = backend_filter_by
         self.retry_policy = retry_policy
-
-    def _validate_retry_policy(self, retry_policy):
-        if retry_policy is None:
-            return
-
-        if not isinstance(retry_policy, dict):
-            raise ValueError("Wrong retry_policy type. Must be a dictionary.")
-
-        if not ({"minimum_backoff", "maximum_backoff"} == set(retry_policy.keys())):
-            raise ValueError("minimum_backoff and maximum_backoff must be provided.")
-
-        if retry_policy.get("minimum_backoff") > retry_policy.get("maximum_backoff"):
-            raise ValueError("minimum_backoff should be less than maximum_backoff.")
 
     def _validate_filter_by(self, filter_by):
         if filter_by and not (

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -35,7 +35,14 @@ class Subscription:
     """
 
     def __init__(
-        self, func, topic, prefix="", suffix="", filter_by=None, backend_filter_by=None
+        self,
+        func,
+        topic,
+        prefix="",
+        suffix="",
+        filter_by=None,
+        backend_filter_by=None,
+        retry_policy=None,
     ):
         self._func = func
         self.topic = topic
@@ -43,6 +50,7 @@ class Subscription:
         self._suffix = suffix
         self._filters = self._init_filters(filter_by)
         self.backend_filter_by = backend_filter_by
+        self.retry_policy = retry_policy
 
     def _init_filters(self, filter_by):
         if filter_by and not (
@@ -60,6 +68,7 @@ class Subscription:
             return [filter_by]
 
         return None
+
 
     @property
     def name(self):

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -208,15 +208,9 @@ def sub(
     :param filter_by: Union[function, list] An optional function or tuple of
                       functions that filters the messages to be processed by
                       the sub regarding their attributes.
-    :param retry_policy: An optional dictionary to define the policy that specifies
-                        how Cloud Pub/Sub retries message delivery. It has two keys;
-                        minimum_backoff: Value should be between 0 and 600 seconds.
-                            Defaults to 10 seconds.
-                        maximum_backoff: Value should be between 0 and 600 seconds.
-                            Defaults to 600 seconds.
+    :param retry_policy: obj :class:`~rele.retry_policy.RetryPolicy`
     :return: :class:`~rele.subscription.Subscription`
     """
-
     def decorator(func):
         args_spec = getfullargspec(func)
         if len(args_spec.args) != 1 or not args_spec.varkw:

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -44,6 +44,8 @@ class Subscription:
         backend_filter_by=None,
         retry_policy=None,
     ):
+        self._validate_retry_policy(retry_policy)
+
         self._func = func
         self.topic = topic
         self._prefix = prefix
@@ -51,6 +53,19 @@ class Subscription:
         self._filters = self._init_filters(filter_by)
         self.backend_filter_by = backend_filter_by
         self.retry_policy = retry_policy
+
+    def _validate_retry_policy(self, retry_policy):
+        if retry_policy is None:
+            return
+
+        if not isinstance(retry_policy, dict):
+            raise ValueError("Wrong retry_policy type. Must be a dictionary.")
+
+        if not ({"minimum_backoff", "maximum_backoff"} == set(retry_policy.keys())):
+            raise ValueError("minimum_backoff and maximum_backoff must be provided.")
+
+        if retry_policy.get("minimum_backoff") > retry_policy.get("maximum_backoff"):
+            raise ValueError("minimum_backoff should be less than maximum_backoff.")
 
     def _init_filters(self, filter_by):
         if filter_by and not (

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -153,7 +153,7 @@ class Callback:
             run_middleware_hook("post_process_message")
 
 
-def sub(topic, prefix=None, suffix=None, filter_by=None, backend_filter_by=None):
+def sub(topic, prefix=None, suffix=None, filter_by=None, backend_filter_by=None, retry_policy=None):
     """Decorator function that makes declaring a PubSub Subscription simple.
 
     The Subscriber returned will automatically create and name
@@ -198,6 +198,12 @@ def sub(topic, prefix=None, suffix=None, filter_by=None, backend_filter_by=None)
     :param filter_by: Union[function, list] An optional function or tuple of
                       functions that filters the messages to be processed by
                       the sub regarding their attributes.
+    :param retry_policy: An optional dictionary to define the policy that specifies
+                        how Cloud Pub/Sub retries message delivery. It has two keys;
+                        minimum_backoff: Value should be between 0 and 600 seconds.
+                            Defaults to 10 seconds.
+                        maximum_backoff: Value should be between 0 and 600 seconds.
+                            Defaults to 600 seconds.
     :return: :class:`~rele.subscription.Subscription`
     """
 
@@ -222,6 +228,7 @@ def sub(topic, prefix=None, suffix=None, filter_by=None, backend_filter_by=None)
             suffix=suffix,
             filter_by=filter_by,
             backend_filter_by=backend_filter_by,
+            retry_policy=retry_policy
         )
 
     return decorator

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -44,6 +44,7 @@ class Subscription:
         backend_filter_by=None,
         retry_policy=None,
     ):
+        self._validate_filter_by(filter_by)
         self._validate_retry_policy(retry_policy)
 
         self._func = func
@@ -67,7 +68,7 @@ class Subscription:
         if retry_policy.get("minimum_backoff") > retry_policy.get("maximum_backoff"):
             raise ValueError("minimum_backoff should be less than maximum_backoff.")
 
-    def _init_filters(self, filter_by):
+    def _validate_filter_by(self, filter_by):
         if filter_by and not (
             callable(filter_by)
             or (
@@ -77,6 +78,7 @@ class Subscription:
         ):
             raise ValueError("Filter_by must be a callable or a list of callables.")
 
+    def _init_filters(self, filter_by):
         if isinstance(filter_by, Iterable):
             return filter_by
         elif filter_by:

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -170,7 +170,14 @@ class Callback:
             run_middleware_hook("post_process_message")
 
 
-def sub(topic, prefix=None, suffix=None, filter_by=None, backend_filter_by=None, retry_policy=None):
+def sub(
+    topic,
+    prefix=None,
+    suffix=None,
+    filter_by=None,
+    backend_filter_by=None,
+    retry_policy=None,
+):
     """Decorator function that makes declaring a PubSub Subscription simple.
 
     The Subscriber returned will automatically create and name
@@ -245,7 +252,7 @@ def sub(topic, prefix=None, suffix=None, filter_by=None, backend_filter_by=None,
             suffix=suffix,
             filter_by=filter_by,
             backend_filter_by=backend_filter_by,
-            retry_policy=retry_policy
+            retry_policy=retry_policy,
         )
 
     return decorator

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -31,7 +31,9 @@ class Worker:
         threads_per_subscription=None,
         default_retry_policy=None,
     ):
-        self._subscriber = Subscriber(gc_project_id, credentials, default_ack_deadline, default_retry_policy)
+        self._subscriber = Subscriber(
+            gc_project_id, credentials, default_ack_deadline, default_retry_policy
+        )
         self._futures = {}
         self._subscriptions = subscriptions
         self.threads_per_subscription = threads_per_subscription

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -29,8 +29,9 @@ class Worker:
         credentials=None,
         default_ack_deadline=None,
         threads_per_subscription=None,
+        default_retry_policy=None,
     ):
-        self._subscriber = Subscriber(gc_project_id, credentials, default_ack_deadline)
+        self._subscriber = Subscriber(gc_project_id, credentials, default_ack_deadline, default_retry_policy)
         self._futures = {}
         self._subscriptions = subscriptions
         self.threads_per_subscription = threads_per_subscription
@@ -152,6 +153,7 @@ def create_and_run(subs, config):
         config.credentials,
         config.ack_deadline,
         config.threads_per_subscription,
+        config.retry_policy,
     )
 
     # to allow killing runrele worker via ctrl+c

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -22,7 +22,7 @@ class TestRunReleCommand:
     def test_calls_worker_start_and_setup_when_runrele(self, mock_worker):
         call_command("runrele")
 
-        mock_worker.assert_called_with([], "rele-test", ANY, 60, 2)
+        mock_worker.assert_called_with([], "rele-test", ANY, 60, 2, None)
         mock_worker.return_value.run_forever.assert_called_once_with()
 
     def test_prints_warning_when_conn_max_age_not_set_to_zero(
@@ -37,5 +37,5 @@ class TestRunReleCommand:
             "This may result in slots for database connections to "
             "be exhausted." in err
         )
-        mock_worker.assert_called_with([], "rele-test", ANY, 60, 2)
+        mock_worker.assert_called_with([], "rele-test", ANY, 60, 2, None)
         mock_worker.return_value.run_forever.assert_called_once_with()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from rele import Publisher
 from rele.client import Subscriber
 from rele.config import Config
 from rele.middleware import register_middleware
+from rele.retry_policy import RetryPolicy
 
 
 @pytest.fixture
@@ -27,7 +28,19 @@ def config(project_id):
             "SUB_PREFIX": "rele",
             "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
             "MIDDLEWARE": ["rele.contrib.LoggingMiddleware"],
-            "DEFAULT_RETRY_POLICY": {"minimum_backoff": 5, "maximum_backoff": 30},
+        }
+    )
+
+
+@pytest.fixture
+def config_with_retry_policy(project_id):
+    return Config(
+        {
+            "APP_NAME": "rele",
+            "SUB_PREFIX": "rele",
+            "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
+            "MIDDLEWARE": ["rele.contrib.LoggingMiddleware"],
+            "DEFAULT_RETRY_POLICY": RetryPolicy(5, 30),
         }
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ def config(project_id):
             "SUB_PREFIX": "rele",
             "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
             "MIDDLEWARE": ["rele.contrib.LoggingMiddleware"],
+            "DEFAULT_RETRY_POLICY": {"minimum_backoff": 5, "maximum_backoff": 30},
         }
     )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,6 +10,8 @@ from google.cloud import pubsub_v1
 from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
 from google.protobuf import duration_pb2
 
+from rele import Subscriber
+from rele.retry_policy import RetryPolicy
 from rele.subscription import Subscription
 
 
@@ -301,11 +303,47 @@ class TestSubscriber:
             minimum_backoff=duration_pb2.Duration(seconds=10),
             maximum_backoff=duration_pb2.Duration(seconds=50),
         )
+
         subscriber.create_subscription(
             Subscription(
                 None,
                 topic=f"{project_id}-test-topic",
-                retry_policy={"minimum_backoff": 10, "maximum_backoff": 50},
+                retry_policy=RetryPolicy(10, 50),
+            )
+        )
+
+        _mocked_client.assert_called_once_with(
+            request={
+                "ack_deadline_seconds": 60,
+                "name": expected_subscription,
+                "topic": expected_topic,
+                "retry_policy": expected_retry_policy,
+            }
+        )
+
+    @patch.object(SubscriberClient, "create_subscription")
+    def test_default_retry_policy_is_applied_when_not_explicitly_provided(
+        self, _mocked_client, project_id, config_with_retry_policy
+    ):
+        subscriber = Subscriber(
+            config_with_retry_policy.gc_project_id,
+            config_with_retry_policy.credentials,
+            60,
+            config_with_retry_policy.retry_policy,
+        )
+        expected_subscription = (
+            f"projects/{project_id}/subscriptions/" f"{project_id}-test-topic"
+        )
+        expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
+        expected_retry_policy = pubsub_v1.types.RetryPolicy(
+            minimum_backoff=duration_pb2.Duration(seconds=5),
+            maximum_backoff=duration_pb2.Duration(seconds=30),
+        )
+
+        subscriber.create_subscription(
+            Subscription(
+                None,
+                topic=f"{project_id}-test-topic",
             )
         )
 

--- a/tests/test_retry_policy.py
+++ b/tests/test_retry_policy.py
@@ -1,0 +1,19 @@
+import pytest
+
+from rele.retry_policy import RetryPolicy
+
+
+class TestRetryPolicy:
+    @pytest.mark.parametrize(
+        "minimum_backoff, maximum_backoff",
+        [
+            (0, 0),
+            (0, 1),
+            (10, 1),
+        ],
+    )
+    def test_value_error_is_raised_instantiating_with_wrong_values(
+        self, minimum_backoff, maximum_backoff
+    ):
+        with pytest.raises(ValueError):
+            RetryPolicy(minimum_backoff, maximum_backoff)

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -131,18 +131,33 @@ class TestSubscription:
                 func=lambda x: None, topic="topic", prefix="rele", filter_by=(1,)
             )
 
-    @pytest.mark.parametrize("retry_policy", [
-        1,
-        (1, 2),
-        {"minimum_viable_product": 1, "maximum_backoff": 10},
-    ])
+    @pytest.mark.parametrize(
+        "retry_policy",
+        [
+            1,
+            (1, 2),
+            {"minimum_viable_product": 1, "maximum_backoff": 10},
+        ],
+    )
     def test_value_error_is_raised_when_bad_format_is_provided(self, retry_policy):
         with pytest.raises(ValueError):
-            Subscription(func=lambda x: None, topic="topic", prefix="rele", retry_policy=retry_policy)
+            Subscription(
+                func=lambda x: None,
+                topic="topic",
+                prefix="rele",
+                retry_policy=retry_policy,
+            )
 
-    def test_value_error_is_raised_when_maximum_backoff_is_smaller_than_minimum_backoff(self):
+    def test_value_error_is_raised_when_maximum_backoff_is_smaller_than_minimum_backoff(
+        self,
+    ):
         with pytest.raises(ValueError):
-            Subscription(func=lambda x: None, topic="topic", prefix="rele", retry_policy={"minimum_backoff": 10, "maximum_backoff": 1})
+            Subscription(
+                func=lambda x: None,
+                topic="topic",
+                prefix="rele",
+                retry_policy={"minimum_backoff": 10, "maximum_backoff": 1},
+            )
 
 
 class TestCallback:
@@ -379,7 +394,10 @@ class TestDecorator:
         subscription = sub(
             topic="topic",
             prefix="rele",
-            retry_policy={"minimum_backoff": 1, "maximum_backoff": 10}
+            retry_policy={"minimum_backoff": 1, "maximum_backoff": 10},
         )(lambda data, **kwargs: None)
 
-        assert subscription.retry_policy == {"minimum_backoff": 1, "maximum_backoff": 10}
+        assert subscription.retry_policy == {
+            "minimum_backoff": 1,
+            "maximum_backoff": 10,
+        }

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -361,3 +361,12 @@ class TestDecorator:
             "Subscription function tests.test_subscription.<lambda> is outside a subs "
             "module that will not be discovered." in caplog.text
         )
+
+    def test_exponential_backoff_is_applied_when_specified(self):
+        subscription = sub(
+            topic="topic",
+            prefix="rele",
+            retry_policy={"minimum_backoff": 1, "maximum_backoff": 10}
+        )(lambda data, **kwargs: None)
+
+        assert subscription.retry_policy == {"minimum_backoff": 1, "maximum_backoff": 10}

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -26,6 +26,7 @@ def worker(config):
         config.credentials,
         default_ack_deadline=60,
         threads_per_subscription=10,
+        default_retry_policy=config.retry_policy
     )
 
 
@@ -160,5 +161,6 @@ class TestCreateAndRun:
         subscriptions = (sub_stub,)
         create_and_run(subscriptions, config)
 
-        mock_worker.assert_called_with(subscriptions, "rele-test", ANY, 60, 2)
+        mock_worker.assert_called_with(
+            subscriptions, "rele-test", ANY, 60, 2, {"minimum_backoff": 5, "maximum_backoff": 30})
         mock_worker.return_value.run_forever.assert_called_once_with()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -26,7 +26,7 @@ def worker(config):
         config.credentials,
         default_ack_deadline=60,
         threads_per_subscription=10,
-        default_retry_policy=config.retry_policy
+        default_retry_policy=config.retry_policy,
     )
 
 
@@ -162,5 +162,11 @@ class TestCreateAndRun:
         create_and_run(subscriptions, config)
 
         mock_worker.assert_called_with(
-            subscriptions, "rele-test", ANY, 60, 2, {"minimum_backoff": 5, "maximum_backoff": 30})
+            subscriptions,
+            "rele-test",
+            ANY,
+            60,
+            2,
+            {"minimum_backoff": 5, "maximum_backoff": 30},
+        )
         mock_worker.return_value.run_forever.assert_called_once_with()


### PR DESCRIPTION
### :tophat: What?

Add retry policy to the subscriptions (exponential backoff).

### :thinking: Why?

This feature allows to configure either a global (per project) retry policy or at subscription level, allowing us leveraging how  we want the subscriptions to behave (retry wise) when worker fails processing a message.

[More info about the feature here](https://cloud.google.com/pubsub/docs/handling-failures).

### :link: Related issue

#222 
