### PR TITLE
Bump to 1.8.0-beta.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.8.0 (2023-04-28)
+-------------------
+* [Added] Add retry policy to subscriptions. (#222)
+
 1.7.0 (2022-11-15)
 -------------------
 * [Added] Add PUBLISHER_BLOCKING setting

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.7.0"
+__version__ = "1.8.0-beta"
 
 try:
     import django


### PR DESCRIPTION
### :tophat: What?

Bump to 1.8.0-beta. This version is released to test the retry policy.

### :link: Related issue

#222
