### PR TITLE
Revert "Use custom encoder in logging middleware"

### DIFF
--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -17,7 +17,6 @@ class LoggingMiddleware(BaseMiddleware):
     def setup(self, config, **kwargs):
         self._logger = logging.getLogger(__name__)
         self._app_name = config.app_name
-        self._encoder = config.encoder
 
     def _build_data_metrics(
         self, subscription, message, status, start_processing_time=None
@@ -72,7 +71,7 @@ class LoggingMiddleware(BaseMiddleware):
                     "name": "publications",
                     "data": {"agent": self._app_name, "topic": topic},
                 },
-                "subscription_message": json.dumps(message, cls=self._encoder),
+                "subscription_message": json.dumps(message),
             },
         )
 

--- a/tests/contrib/test_logging_middleware.py
+++ b/tests/contrib/test_logging_middleware.py
@@ -1,11 +1,8 @@
-from decimal import Decimal
-import os
 import queue
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from google.cloud import pubsub_v1
-from rele.config import Config
 
 from rele.contrib.logging_middleware import LoggingMiddleware
 from tests.subs import sub_stub
@@ -19,11 +16,6 @@ def message_data():
 @pytest.fixture
 def expected_message_data_log():
     return '{"foo": "bar"}'
-
-
-@pytest.fixture
-def expected_message_data_log_with_decimal():
-    return '{"foo": "1"}'
 
 
 @pytest.fixture
@@ -57,16 +49,6 @@ class TestLoggingMiddleware:
         logging_middleware.setup(config)
         return logging_middleware
 
-    @pytest.fixture
-    def logging_middleware_with_custom_encoder(self, logging_middleware):
-        config = Config(
-            {
-                "ENCODER_PATH": "django.core.serializers.json.DjangoJSONEncoder",
-            }
-        )
-        logging_middleware.setup(config)
-        return logging_middleware
-
     def test_message_payload_log_is_converted_to_string_on_post_publish_failure(
         self,
         logging_middleware,
@@ -81,23 +63,6 @@ class TestLoggingMiddleware:
         message_log = caplog.records[0].subscription_message
 
         assert message_log == expected_message_data_log
-
-    def test_message_payload_log_uses_custom_encoder(
-        self,
-        logging_middleware_with_custom_encoder,
-        caplog,
-        message_data,
-        expected_message_data_log_with_decimal,
-    ):
-        message_data["foo"] = Decimal(1)
-
-        logging_middleware_with_custom_encoder.post_publish_failure(
-            sub_stub, RuntimeError("💩"), message_data
-        )
-
-        message_log = caplog.records[0].subscription_message
-
-        assert message_log == expected_message_data_log_with_decimal
 
     def test_message_payload_log_is_converted_to_string_on_post_process_message_failure(
         self,


### PR DESCRIPTION
Reverts mercadona/rele#239 to promote v1.8.0-beta.