### PR TITLE
Add logs when a worker is stopped

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.8.1 (2023-05-08)
+-------------------
+* [Added] Add logs when a worker is stopped
+
 1.8.0 (2023-04-28)
 -------------------
 * [Added] Add retry policy to subscriptions. (#222)

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 
 try:
     import django

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -88,11 +88,19 @@ class Worker:
         :param signal: Needed for `signal.signal <https://docs.python.org/3/library/signal.html#signal.signal>`_  # noqa
         :param frame: Needed for `signal.signal <https://docs.python.org/3/library/signal.html#signal.signal>`_  # noqa
         """
+
+        logger.info(f"[rele] {signal} received, stopping workers")
+
         run_middleware_hook("pre_worker_stop", self._subscriptions)
         for future in self._futures.values():
             future.cancel()
 
+        logger.info("[rele] future cancelled")
+
         run_middleware_hook("post_worker_stop")
+
+        logger.info("[rele] worker stopped")
+
         sys.exit(0)
 
     def _boostrap_consumption(self, subscription):

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -89,17 +89,17 @@ class Worker:
         :param frame: Needed for `signal.signal <https://docs.python.org/3/library/signal.html#signal.signal>`_  # noqa
         """
 
-        logger.info(f"[rele] {signal} received, stopping workers")
+        logger.info(f"Rele receive {signal} signal, stopping worker")
 
         run_middleware_hook("pre_worker_stop", self._subscriptions)
         for future in self._futures.values():
             future.cancel()
 
-        logger.info("[rele] future cancelled")
+        logger.info("Rele cancel all futures")
 
         run_middleware_hook("post_worker_stop")
 
-        logger.info("[rele] worker stopped")
+        logger.info("Rele worker stopped")
 
         sys.exit(0)
 


### PR DESCRIPTION
### :tophat: What?
Add logs to trace how the worker is being stopped

### :thinking: Why?
To have more data to understand what is happening

### :link: Related issue
