### PR TITLE
[Changed] Bumped rele version to 1.12.0b1

### DIFF
--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.11.0"
+__version__ = "1.12.0b1"
 
 try:
     import django


### PR DESCRIPTION
### :tophat: What?

Bumped rele version to 1.12.0b1

### :thinking: Why?

To be able to detect subscriber on different folder levels.

### :link: Related issue

[Related PR](https://github.com/mercadona/rele/commit/f3ec931adf1f9f7051237f8f77c5b5494c3d0351)
