### PR TITLE
Update with Python 3.11 support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -57,10 +57,10 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     entry_points={"console_scripts": ["rele-cli=rele.__main__:main"]},
 )


### PR DESCRIPTION
### :tophat: What?

Added Python 3.11 support in the CI as well as updating the metadata in the setup.py file

### :thinking: Why?

Python 3.8 is EOL and Python 3.11 has been out for a while now. 

