### PR TITLE
[Added] Bump rele version to `1.13.0`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Changelog
 -------------------
 * [Added] Add verbosity to `VerboseLoggingMiddleware`'s hooks (#240)
 
+1.12.0 (2023-07-17)
+-------------------
+* [Added] Check if subs have same memory address (#257)
+* [Changed] Detect subs module at any folder level (#255)
+
 1.11.0 (2023-05-09)
 -------------------
 * [Added] Allow updating retry policy to existing subscriptions. (#248)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.13.0 (2023-09-04)
+-------------------
+* [Added] Add verbosity to `VerboseLoggingMiddleware`'s hooks (#240)
+
 1.11.0 (2023-05-09)
 -------------------
 * [Added] Allow updating retry policy to existing subscriptions. (#248)

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.12.0"
+__version__ = "1.13.0"
 
 try:
     import django


### PR DESCRIPTION
### :tophat: What?
Update `rele` to version `1.13.0`

### :thinking: Why?
We recently added changes to the `VerboseLoggingMiddleware` and want to publish them in a new version.

### :link: Related issue

https://github.com/mercadona/rele/pull/240
