### PR TITLE
Added a setting to provide client options for Pub/Sub clients

### DIFF
--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.14.0"
+__version__ = "1.15.0b0"
 
 try:
     import django

--- a/rele/client.py
+++ b/rele/client.py
@@ -48,6 +48,7 @@ class Subscriber:
         gc_project_id,
         credentials,
         message_storage_policy,
+        client_options,
         default_ack_deadline=None,
         default_retry_policy=None,
     ):

--- a/rele/client.py
+++ b/rele/client.py
@@ -56,7 +56,9 @@ class Subscriber:
         self._ack_deadline = default_ack_deadline or DEFAULT_ACK_DEADLINE
         self.credentials = credentials if not USE_EMULATOR else None
         self._message_storage_policy = message_storage_policy
-        self._client = pubsub_v1.SubscriberClient(credentials=credentials, client_options=client_options)
+        self._client = pubsub_v1.SubscriberClient(
+            credentials=credentials, client_options=client_options
+        )
         self._retry_policy = default_retry_policy
 
     def update_or_create_subscription(self, subscription):
@@ -183,7 +185,15 @@ class Publisher:
     :param blocking: boolean, default None falls back to :ref:`settings_publisher_blocking`
     """
 
-    def __init__(self, gc_project_id, credentials, encoder, timeout, client_options, blocking=None):
+    def __init__(
+        self,
+        gc_project_id,
+        credentials,
+        encoder,
+        timeout,
+        client_options,
+        blocking=None,
+    ):
         self._gc_project_id = gc_project_id
         self._timeout = timeout
         self._blocking = blocking
@@ -191,7 +201,9 @@ class Publisher:
         if USE_EMULATOR:
             self._client = pubsub_v1.PublisherClient()
         else:
-            self._client = pubsub_v1.PublisherClient(credentials=credentials, client_options=client_options)
+            self._client = pubsub_v1.PublisherClient(
+                credentials=credentials, client_options=client_options
+            )
 
     def publish(
         self, topic, data, blocking=None, timeout=None, raise_exception=True, **attrs

--- a/rele/client.py
+++ b/rele/client.py
@@ -56,7 +56,7 @@ class Subscriber:
         self._ack_deadline = default_ack_deadline or DEFAULT_ACK_DEADLINE
         self.credentials = credentials if not USE_EMULATOR else None
         self._message_storage_policy = message_storage_policy
-        self._client = pubsub_v1.SubscriberClient(credentials=credentials)
+        self._client = pubsub_v1.SubscriberClient(credentials=credentials, client_options=client_options)
         self._retry_policy = default_retry_policy
 
     def update_or_create_subscription(self, subscription):

--- a/rele/client.py
+++ b/rele/client.py
@@ -190,7 +190,7 @@ class Publisher:
         if USE_EMULATOR:
             self._client = pubsub_v1.PublisherClient()
         else:
-            self._client = pubsub_v1.PublisherClient(credentials=credentials)
+            self._client = pubsub_v1.PublisherClient(credentials=credentials, client_options=client_options)
 
     def publish(
         self, topic, data, blocking=None, timeout=None, raise_exception=True, **attrs

--- a/rele/client.py
+++ b/rele/client.py
@@ -182,7 +182,7 @@ class Publisher:
     :param blocking: boolean, default None falls back to :ref:`settings_publisher_blocking`
     """
 
-    def __init__(self, gc_project_id, credentials, encoder, timeout, blocking=None):
+    def __init__(self, gc_project_id, credentials, encoder, timeout, client_options, blocking=None):
         self._gc_project_id = gc_project_id
         self._timeout = timeout
         self._blocking = blocking

--- a/rele/config.py
+++ b/rele/config.py
@@ -43,6 +43,7 @@ class Config:
         self.filter_by = setting.get("FILTER_SUBS_BY")
         self._credentials = None
         self.retry_policy = setting.get("DEFAULT_RETRY_POLICY")
+        self.client_options = setting.get("CLIENT_OPTIONS")
 
     @property
     def encoder(self):

--- a/rele/publishing.py
+++ b/rele/publishing.py
@@ -14,7 +14,7 @@ def init_global_publisher(config):
             encoder=config.encoder,
             timeout=config.publisher_timeout,
             blocking=config.publisher_blocking,
-            client_options=config.client_options
+            client_options=config.client_options,
         )
     return _publisher
 

--- a/rele/publishing.py
+++ b/rele/publishing.py
@@ -14,6 +14,7 @@ def init_global_publisher(config):
             encoder=config.encoder,
             timeout=config.publisher_timeout,
             blocking=config.publisher_blocking,
+            client_options=config.client_options
         )
     return _publisher
 

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -48,6 +48,7 @@ class Worker:
     def __init__(
         self,
         subscriptions,
+        client_options,
         gc_project_id=None,
         credentials=None,
         gc_storage_region=None,
@@ -59,6 +60,7 @@ class Worker:
             gc_project_id,
             credentials,
             gc_storage_region,
+            client_options,
             default_ack_deadline,
             default_retry_policy,
         )
@@ -228,6 +230,7 @@ def create_and_run(subs, config):
         print(f"Subscription: {sub}")
     worker = Worker(
         subs,
+        config.client_options,
         config.gc_project_id,
         config.credentials,
         config.gc_storage_region,

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -18,7 +18,7 @@ class TestRunReleCommand:
         call_command("runrele")
 
         mock_worker.assert_called_with(
-            [], "rele-test", ANY, "europe-west1", 60, 2, None
+            [], None, "rele-test", ANY, "europe-west1", 60, 2, None
         )
         mock_worker.return_value.run_forever.assert_called_once_with()
 
@@ -35,6 +35,6 @@ class TestRunReleCommand:
             "be exhausted." in err
         )
         mock_worker.assert_called_with(
-            [], "rele-test", ANY, "europe-west1", 60, 2, None
+            [], None, "rele-test", ANY, "europe-west1", 60, 2, None
         )
         mock_worker.return_value.run_forever.assert_called_once_with()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,7 @@ def publisher(config, mock_future):
         encoder=config.encoder,
         timeout=config.publisher_timeout,
         blocking=config.publisher_blocking,
+        client_options=config.client_options
     )
     publisher._client = MagicMock(spec=PublisherClient)
     publisher._client.publish.return_value = mock_future

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ def config(project_id):
             "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
             "GC_STORAGE_REGION": "some-region",
             "MIDDLEWARE": ["rele.contrib.LoggingMiddleware"],
+            "CLIENT_OPTIONS": {"api_endpoint": "custom-api.interconnect.example.com"},
         }
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def mock_worker():
 @pytest.fixture
 def subscriber(project_id, config):
     return Subscriber(
-        config.gc_project_id, config.credentials, config.gc_storage_region, 60
+        config.gc_project_id, config.credentials, config.gc_storage_region, config.client_options, 60
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,11 @@ def mock_worker():
 @pytest.fixture
 def subscriber(project_id, config):
     return Subscriber(
-        config.gc_project_id, config.credentials, config.gc_storage_region, config.client_options, 60
+        config.gc_project_id,
+        config.credentials,
+        config.gc_storage_region,
+        config.client_options,
+        60,
     )
 
 
@@ -74,7 +78,7 @@ def publisher(config, mock_future):
         encoder=config.encoder,
         timeout=config.publisher_timeout,
         blocking=config.publisher_blocking,
-        client_options=config.client_options
+        client_options=config.client_options,
     )
     publisher._client = MagicMock(spec=PublisherClient)
     publisher._client.publish.return_value = mock_future

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -2,13 +2,31 @@ import concurrent
 import decimal
 import logging
 from concurrent.futures import TimeoutError
-from unittest.mock import ANY
+from unittest.mock import ANY, patch
 
 import pytest
+
+from rele import Publisher
 
 
 @pytest.mark.usefixtures("publisher", "time_mock")
 class TestPublisher:
+    def test_initialises_with_correct_parameters(self, config ):
+        with patch("rele.client.pubsub_v1.PublisherClient") as mock:
+            Publisher(
+                gc_project_id=config.gc_project_id,
+                credentials=config.credentials,
+                encoder=config.encoder,
+                timeout=config.publisher_timeout,
+                blocking=config.publisher_blocking,
+                client_options=config.client_options
+            )
+
+            mock.assert_called_with(
+                credentials=ANY,
+                client_options={"api_endpoint": "custom-api.interconnect.example.com"}
+            )
+
     def test_returns_future_when_published_called(self, published_at, publisher):
         message = {"foo": "bar"}
         result = publisher.publish(

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -11,21 +11,21 @@ from rele import Publisher
 
 @pytest.mark.usefixtures("publisher", "time_mock")
 class TestPublisher:
-    def test_initialises_with_correct_parameters(self, config):
-        with patch("rele.client.pubsub_v1.PublisherClient") as mock:
-            Publisher(
-                gc_project_id=config.gc_project_id,
-                credentials=config.credentials,
-                encoder=config.encoder,
-                timeout=config.publisher_timeout,
-                blocking=config.publisher_blocking,
-                client_options=config.client_options,
-            )
+    @patch("rele.client.pubsub_v1.PublisherClient", autospec=True)
+    def test_initialises_with_correct_parameters(self, mock_publisher_client, config):
+        Publisher(
+            gc_project_id=config.gc_project_id,
+            credentials=config.credentials,
+            encoder=config.encoder,
+            timeout=config.publisher_timeout,
+            blocking=config.publisher_blocking,
+            client_options=config.client_options,
+        )
 
-            mock.assert_called_with(
-                credentials=ANY,
-                client_options={"api_endpoint": "custom-api.interconnect.example.com"},
-            )
+        mock_publisher_client.assert_called_with(
+            credentials=ANY,
+            client_options={"api_endpoint": "custom-api.interconnect.example.com"},
+        )
 
     def test_returns_future_when_published_called(self, published_at, publisher):
         message = {"foo": "bar"}

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -11,7 +11,7 @@ from rele import Publisher
 
 @pytest.mark.usefixtures("publisher", "time_mock")
 class TestPublisher:
-    def test_initialises_with_correct_parameters(self, config ):
+    def test_initialises_with_correct_parameters(self, config):
         with patch("rele.client.pubsub_v1.PublisherClient") as mock:
             Publisher(
                 gc_project_id=config.gc_project_id,
@@ -19,12 +19,12 @@ class TestPublisher:
                 encoder=config.encoder,
                 timeout=config.publisher_timeout,
                 blocking=config.publisher_blocking,
-                client_options=config.client_options
+                client_options=config.client_options,
             )
 
             mock.assert_called_with(
                 credentials=ANY,
-                client_options={"api_endpoint": "custom-api.interconnect.example.com"}
+                client_options={"api_endpoint": "custom-api.interconnect.example.com"},
             )
 
     def test_returns_future_when_published_called(self, published_at, publisher):

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch, Mock, ANY
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest
 
@@ -52,9 +52,7 @@ class TestInitGlobalPublisher:
         assert id(publishing._publisher) == publisher_id
 
     @patch("rele.publishing.Publisher", autospec=True)
-    def test_creates_publisher_with_api_endpoint_option(
-        self, mock_publisher, config
-    ):
+    def test_creates_publisher_with_api_endpoint_option(self, mock_publisher, config):
         publishing._publisher = None
         mock_publisher.return_value = MagicMock(spec=Publisher)
         publishing.init_global_publisher(config)
@@ -63,7 +61,7 @@ class TestInitGlobalPublisher:
         publishing.publish(topic="order-cancelled", data=message, myattr="hello")
 
         mock_publisher.assert_called_with(
-            gc_project_id='rele-test',
+            gc_project_id="rele-test",
             credentials=ANY,
             encoder=ANY,
             timeout=3.0,

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -53,16 +53,8 @@ class TestInitGlobalPublisher:
 
     @patch("rele.publishing.Publisher", autospec=True)
     def test_creates_publisher_with_api_endpoint_option(
-        self, mock_publisher
+        self, mock_publisher, config
     ):
-        config = Config({
-            "APP_NAME": "rele",
-            "SUB_PREFIX": "rele",
-            "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
-            "GC_STORAGE_REGION": "some-region",
-            "MIDDLEWARE": ["rele.contrib.LoggingMiddleware"],
-            "CLIENT_OPTIONS": {"api_endpoint": "custom-api.interconnect.example.com"},
-        })
         publishing._publisher = None
         mock_publisher.return_value = MagicMock(spec=Publisher)
         publishing.init_global_publisher(config)

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch, Mock
+from unittest.mock import MagicMock, patch, Mock, ANY
 
 import pytest
 
@@ -53,7 +53,7 @@ class TestInitGlobalPublisher:
 
     @patch("rele.publishing.Publisher", autospec=True)
     def test_creates_publisher_with_api_endpoint_option(
-        self, mock_publisher: Mock
+        self, mock_publisher
     ):
         config = Config({
             "APP_NAME": "rele",
@@ -61,7 +61,7 @@ class TestInitGlobalPublisher:
             "GC_CREDENTIALS_PATH": "tests/dummy-pub-sub-credentials.json",
             "GC_STORAGE_REGION": "some-region",
             "MIDDLEWARE": ["rele.contrib.LoggingMiddleware"],
-            "API_ENDPOINT": "custom-api.interconnect.example.com",
+            "CLIENT_OPTIONS": {"api_endpoint": "custom-api.interconnect.example.com"},
         })
         publishing._publisher = None
         mock_publisher.return_value = MagicMock(spec=Publisher)
@@ -72,9 +72,9 @@ class TestInitGlobalPublisher:
 
         mock_publisher.assert_called_with(
             gc_project_id='rele-test',
-            credentials=config.credentials,
-            encoder=config.encoder,
+            credentials=ANY,
+            encoder=ANY,
             timeout=3.0,
             blocking=False,
-            api_endpoint='custom-api.interconnect.example.com',
+            client_options={"api_endpoint": "custom-api.interconnect.example.com"},
         )

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, ANY
+from unittest.mock import ANY, patch
 
 import pytest
 from google.api_core import exceptions
@@ -22,7 +22,9 @@ class TestSubscriber:
             yield mock
 
     @patch("rele.client.pubsub_v1.SubscriberClient", autospec=True)
-    def test_creates_subscriber_client_with_client_options(self, mock_subscriber_client, config):
+    def test_creates_subscriber_client_with_client_options(
+        self, mock_subscriber_client, config
+    ):
         Subscriber(
             gc_project_id=config.gc_project_id,
             credentials=config.credentials,
@@ -33,7 +35,7 @@ class TestSubscriber:
 
         mock_subscriber_client.assert_called_with(
             credentials=ANY,
-            client_options={"api_endpoint": "custom-api.interconnect.example.com"}
+            client_options={"api_endpoint": "custom-api.interconnect.example.com"},
         )
 
     @patch.object(SubscriberClient, "create_subscription")

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -212,6 +212,7 @@ class TestSubscriber:
             config_with_retry_policy.gc_project_id,
             config_with_retry_policy.credentials,
             config_with_retry_policy.gc_storage_region,
+            config_with_retry_policy.client_options,
             60,
             config_with_retry_policy.retry_policy,
         )

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, ANY
 
 import pytest
 from google.api_core import exceptions
@@ -20,6 +20,21 @@ class TestSubscriber:
             PublisherClient, "create_topic", return_values={"name": "test-topic"}
         ) as mock:
             yield mock
+
+    @patch("rele.client.pubsub_v1.SubscriberClient", autospec=True)
+    def test_creates_subscriber_client_with_client_options(self, mock_subscriber_client, config):
+        Subscriber(
+            gc_project_id=config.gc_project_id,
+            credentials=config.credentials,
+            message_storage_policy=config.gc_storage_region,
+            client_options={"api_endpoint": "custom-api.interconnect.example.com"},
+            default_ack_deadline=60,
+        )
+
+        mock_subscriber_client.assert_called_with(
+            credentials=ANY,
+            client_options={"api_endpoint": "custom-api.interconnect.example.com"}
+        )
 
     @patch.object(SubscriberClient, "create_subscription")
     @patch.object(SubscriberClient, "update_subscription")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -258,9 +258,9 @@ class TestCreateAndRun:
         create_and_run(subscriptions, config)
 
         mock_subscriber.assert_called_with(
-            'rele-test',
+            "rele-test",
             ANY,
-            'some-region',
+            "some-region",
             {"api_endpoint": "custom-api.interconnect.example.com"},
             60,
             None,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -252,21 +252,13 @@ class TestCreateAndRun:
 
     def test_creates_subscriber_with_correct_arguments(self, mock_subscriber, config):
         subscriptions = (sub_stub,)
-        Worker(
-            subscriptions,
-            config.gc_project_id,
-            config.credentials,
-            config.gc_storage_region,
-            default_ack_deadline=60,
-            threads_per_subscription=10,
-            default_retry_policy=config.retry_policy,
-        )
+        create_and_run(subscriptions, config)
 
         mock_subscriber.assert_called_with(
             'rele-test',
             ANY,
             'some-region',
+            {"api_endpoint": "custom-api.interconnect.example.com"},
             60,
             None,
-            {"api_endpoint": "custom-api.interconnect.example.com"}
         )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -26,6 +26,7 @@ def worker(config):
     subscriptions = (sub_stub,)
     return Worker(
         subscriptions,
+        config.client_options,
         config.gc_project_id,
         config.credentials,
         config.gc_storage_region,
@@ -115,6 +116,7 @@ class TestWorker:
         custom_ack_deadline = 234
         worker = Worker(
             subscriptions,
+            config.client_options,
             config.gc_project_id,
             config.gc_storage_region,
             config.credentials,
@@ -241,6 +243,7 @@ class TestCreateAndRun:
 
         mock_worker.assert_called_with(
             subscriptions,
+            None,
             "rele-test",
             ANY,
             "some-region",


### PR DESCRIPTION
### :tophat: What?

Added `CLIENT_OPTIONS` settings to provide configurations for the Pub/Sub [publisher](https://cloud.google.com/python/docs/reference/pubsub/latest/google.cloud.pubsub_v1.publisher.client.Client#google_cloud_pubsub_v1_publisher_client_Client_api_endpoint) and [subscriber](https://cloud.google.com/python/docs/reference/pubsub/latest/google.cloud.pubsub_v1.subscriber.client.Client#google_cloud_pubsub_v1_subscriber_client_Client) clients.

```
RELE = {
    # other settings
    "CLIENT_OPTIONS": {"api_endpoint": "custom-api.interconnect.example.com"},
}
```
### :thinking: Why?
We want to ability to update the global endpoint for publisher and subscriber clients. 

### :link: Related issue
