### PR TITLE
Check internet connection using api_endpoint if present in CLIENT_OPTIONS settings

### DIFF
--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.15.0b0"
+__version__ = "1.15.0b1"
 
 try:
     import django

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -66,7 +66,7 @@ class Worker:
         self._futures: Dict[str, Future] = {}
         self._subscriptions = subscriptions
         self.threads_per_subscription = threads_per_subscription
-        self.internet_check_endpoint = client_options.get("api_endpoint") if client_options is not None else "www.google.com"
+        self.internet_check_endpoint = client_options.get("api_endpoint") if client_options is not None and client_options.get("api_endpoint") is not None else "www.google.com"
 
     def setup(self):
         """Create the subscriptions on a Google PubSub topic.

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -66,7 +66,12 @@ class Worker:
         self._futures: Dict[str, Future] = {}
         self._subscriptions = subscriptions
         self.threads_per_subscription = threads_per_subscription
-        self.internet_check_endpoint = client_options.get("api_endpoint") if client_options is not None and client_options.get("api_endpoint") is not None else "www.google.com"
+        self.internet_check_endpoint = self._get_internet_check_endpoint(client_options)
+
+    def _get_internet_check_endpoint(self, client_options):
+        if client_options is not None and client_options.get("api_endpoint") is not None:
+            return client_options.get("api_endpoint")
+        return "www.google.com"
 
     def setup(self):
         """Create the subscriptions on a Google PubSub topic.

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -69,7 +69,10 @@ class Worker:
         self.internet_check_endpoint = self._get_internet_check_endpoint(client_options)
 
     def _get_internet_check_endpoint(self, client_options):
-        if client_options is not None and client_options.get("api_endpoint") is not None:
+        if (
+            client_options is not None
+            and client_options.get("api_endpoint") is not None
+        ):
             return client_options.get("api_endpoint")
         return "www.google.com"
 
@@ -186,7 +189,9 @@ class Worker:
         while True:
             logger.debug(f"[_wait_forever][0] Futures: {self._futures.values()}")
 
-            if datetime.now().timestamp() % 50 < 1 and not check_internet_connection(self.internet_check_endpoint):
+            if datetime.now().timestamp() % 50 < 1 and not check_internet_connection(
+                self.internet_check_endpoint
+            ):
                 logger.debug("Not internet connection, raising an Exception")
                 raise NotConnectionError
 

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -21,9 +21,8 @@ class NotConnectionError(BaseException):
     pass
 
 
-def check_internet_connection():
+def check_internet_connection(remote_server="www.google.com"):
     logger.debug("Checking connection")
-    remote_server = "www.google.com"
     port = 80
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(5)

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -181,7 +181,7 @@ class Worker:
         while True:
             logger.debug(f"[_wait_forever][0] Futures: {self._futures.values()}")
 
-            if datetime.now().timestamp() % 50 < 1 and not check_internet_connection():
+            if datetime.now().timestamp() % 50 < 1 and not check_internet_connection(self.internet_check_endpoint):
                 logger.debug("Not internet connection, raising an Exception")
                 raise NotConnectionError
 

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -21,7 +21,7 @@ class NotConnectionError(BaseException):
     pass
 
 
-def check_internet_connection(remote_server="www.google.com"):
+def check_internet_connection(remote_server):
     logger.debug("Checking connection")
     port = 80
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -66,6 +66,7 @@ class Worker:
         self._futures: Dict[str, Future] = {}
         self._subscriptions = subscriptions
         self.threads_per_subscription = threads_per_subscription
+        self.internet_check_endpoint = client_options.get("api_endpoint") if client_options is not None else "www.google.com"
 
     def setup(self):
         """Create the subscriptions on a Google PubSub topic.
@@ -151,7 +152,7 @@ class Worker:
                 "future cancelled and result"
             )
 
-        if not check_internet_connection():
+        if not check_internet_connection(self.internet_check_endpoint):
             logger.debug(
                 f"Not internet "
                 f"connection when boostrap a consumption for {subscription}"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -152,7 +152,7 @@ class TestWorker:
             worker_without_client_options.start()
         mock_internet_connection.assert_called_once_with("www.google.com")
 
-    def test_check_internet_connection_with_defult_endpoint_if_client_options_do_not_have_api_endpoint(
+    def test_check_internet_connection_with_default_endpoint_if_client_options_do_not_have_api_endpoint(
         self, config, mock_internet_connection
     ):
         mock_internet_connection.return_value = False
@@ -171,7 +171,6 @@ class TestWorker:
         with pytest.raises(NotConnectionError):
             worker.start()
         mock_internet_connection.assert_called_once_with("www.google.com")
-
 
     def test_check_internet_connection_uses_api_endpoint_setting_when_present(
         self, worker, mock_internet_connection

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -179,7 +179,9 @@ class TestWorker:
 
         with pytest.raises(NotConnectionError):
             worker.start()
-        mock_internet_connection.assert_called_once_with("custom-api.interconnect.example.com")
+        mock_internet_connection.assert_called_once_with(
+            "custom-api.interconnect.example.com"
+        )
 
 
 @pytest.mark.usefixtures("mock_create_subscription")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -135,6 +135,16 @@ class TestWorker:
 
         with pytest.raises(NotConnectionError):
             worker.start()
+        mock_internet_connection.assert_called_once_with()
+
+    def test_check_internet_connection_uses_api_endpoint_setting_when_present(
+        self, worker, mock_internet_connection
+    ):
+        mock_internet_connection.return_value = False
+
+        with pytest.raises(NotConnectionError):
+            worker.start()
+        mock_internet_connection.assert_called_once_with(remote_server="custom-api.interconnect.example.com")
 
 
 @pytest.mark.usefixtures("mock_create_subscription")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -152,6 +152,27 @@ class TestWorker:
             worker_without_client_options.start()
         mock_internet_connection.assert_called_once_with("www.google.com")
 
+    def test_check_internet_connection_with_defult_endpoint_if_client_options_do_not_have_api_endpoint(
+        self, config, mock_internet_connection
+    ):
+        mock_internet_connection.return_value = False
+        subscriptions = (sub_stub,)
+        worker = Worker(
+            subscriptions,
+            {},
+            config.gc_project_id,
+            config.credentials,
+            config.gc_storage_region,
+            default_ack_deadline=60,
+            threads_per_subscription=10,
+            default_retry_policy=config.retry_policy,
+        )
+
+        with pytest.raises(NotConnectionError):
+            worker.start()
+        mock_internet_connection.assert_called_once_with("www.google.com")
+
+
     def test_check_internet_connection_uses_api_endpoint_setting_when_present(
         self, worker, mock_internet_connection
     ):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -135,7 +135,7 @@ class TestWorker:
 
         with pytest.raises(NotConnectionError):
             worker.start()
-        mock_internet_connection.assert_called_once_with()
+        mock_internet_connection.assert_called_once_with("www.google.com")
 
     def test_check_internet_connection_uses_api_endpoint_setting_when_present(
         self, worker, mock_internet_connection
@@ -144,7 +144,7 @@ class TestWorker:
 
         with pytest.raises(NotConnectionError):
             worker.start()
-        mock_internet_connection.assert_called_once_with(remote_server="custom-api.interconnect.example.com")
+        mock_internet_connection.assert_called_once_with("custom-api.interconnect.example.com")
 
 
 @pytest.mark.usefixtures("mock_create_subscription")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -67,7 +67,7 @@ def mock_create_subscription():
 
 @pytest.fixture(autouse=True)
 def mock_internet_connection():
-    with patch("rele.worker.check_internet_connection") as m:
+    with patch("rele.worker.check_internet_connection", autospec=True) as m:
         m.return_value = True
         yield m
 


### PR DESCRIPTION
### :tophat: What?

Updated how we check the internet connection. Previously we were using `www.google.com` to check the internet connection. Since we added the option to provide `api_endpoint` via  CLIENT_OPTIONS settings, we want to use the same endpoint to check the internet connection.

### :thinking: Why?

In cases when we are connecting to different endpoint for example (interconnect), we want to check the internet connection using that endpoint.

### :link: Related issue

