### PR TITLE
Bump version to 1.15.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+1.15.0 (2024-02-29)
+-------------------
+* [Added] Add a setting CLIENT_OPTIONS for Pub/Sub clients (#274)
+* [Changed] Use api_endpoint from CLIENT_OPTIONS to check loss of network connectivity(#275)
+
+1.14.0 (2024-02-01)
+-------------------
+* [Fixed] Restart worker when get in an inconsistent status due a loss of network connectivity (#267)
+* [Added] Allow --third-party-subscriptions argument in rele-cli run command for stand alone workers (#269)
+
 1.13.0 (2023-09-04)
 -------------------
 * [Added] Add verbosity to `VerboseLoggingMiddleware`'s hooks (#240)

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -32,6 +32,7 @@ Example::
         'FILTER_SUBS_BY': boolean_function,
         'DEFAULT_RETRY_POLICY': RetryPolicy(10, 50),
         'GC_STORAGE_REGION': 'europe-west1',
+        'CLIENT_OPTIONS': {'api_endpoint': 'custom-api.interconnect.example.com'}
     }
 
 ``GC_PROJECT_ID``
@@ -195,3 +196,18 @@ RetryPolicy will be triggered on NACKs or acknowledgement deadline exceeded even
 **Optional**
 
 Set the Google Cloud's region for storing the messages. By default is `europe-west1`
+
+``CLIENT_OPTIONS``
+----------------------------
+
+**Optional**
+
+Set custom options for the client.
+
+1. The api_endpoint property can be used to override the default endpoint provided by the client when transport is not explicitly provided.
+
+2. The client_cert_source property can be used to provide a client certificate for mTLS transport. If not provided, the default SSL client certificate will be used if present.
+
+3. The universe_domain property can be used to override the default "googleapis.com" universe. Note that the api_endpoint property still takes precedence; and universe_domain is currently not supported for mTLS.
+
+For more information, please see `Publisher Client <https://cloud.google.com/python/docs/reference/pubsub/latest/google.cloud.pubsub_v1.publisher.client.Client>`_ and `Subscriber Client <https://cloud.google.com/python/docs/reference/pubsub/latest/google.cloud.pubsub_v1.subscriber.client.Client>`_.

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.15.0b1"
+__version__ = "1.15.0"
 
 try:
     import django


### PR DESCRIPTION
### :tophat: What?
Bump version to 1.15.0
Update the documentation
Update the changelog
### :thinking: Why?
release new features:

1.15.0 (2024-02-29)
-------------------
* [Added] Add a setting CLIENT_OPTIONS for Pub/Sub clients (#274)
* [Changed] Use api_endpoint from CLIENT_OPTIONS to check loss of network connectivity(#275)

### :link: Related issue

Add related issue's number. Example: Fix #1
