### PR TITLE
Add message retention parameter

### DIFF
--- a/rele/client.py
+++ b/rele/client.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 USE_EMULATOR = True if os.environ.get("PUBSUB_EMULATOR_HOST") else False
 DEFAULT_ENCODER_PATH = "json.JSONEncoder"
 DEFAULT_ACK_DEADLINE = 60
+DEFAULT_MESSAGE_RETENTION_DURATION = "7d"
 DEFAULT_BLOCKING = False
 
 
@@ -51,9 +52,13 @@ class Subscriber:
         client_options,
         default_ack_deadline=None,
         default_retry_policy=None,
+        default_message_retention_duration=None,
     ):
         self._gc_project_id = gc_project_id
         self._ack_deadline = default_ack_deadline or DEFAULT_ACK_DEADLINE
+        self._message_retention_duration = (
+            default_message_retention_duration or DEFAULT_MESSAGE_RETENTION_DURATION
+        )
         self.credentials = credentials if not USE_EMULATOR else None
         self._message_storage_policy = message_storage_policy
         self._client = pubsub_v1.SubscriberClient(
@@ -105,6 +110,7 @@ class Subscriber:
             "name": subscription_path,
             "topic": topic_path,
             "ack_deadline_seconds": self._ack_deadline,
+            "message_retention_duration": self._message_retention_duration,
         }
 
         if subscription.backend_filter_by:

--- a/rele/client.py
+++ b/rele/client.py
@@ -127,23 +127,20 @@ class Subscriber:
         retry_policy = subscription.retry_policy or self._retry_policy
         message_retention_duration = self._message_retention_duration
 
+        subscription_parameters = {
+            "name": subscription_path,
+            "topic": topic_path,
+            "message_retention_duration": message_retention_duration,
+        }
+
         mask_fields = ["message_retention_duration"]
 
         if retry_policy:
             mask_fields.append("retry_policy")
             client_retry_policy = self._build_gcloud_retry_policy(retry_policy)
-            subscription = pubsub_v1.types.Subscription(
-                name=subscription_path,
-                topic=topic_path,
-                retry_policy=client_retry_policy,
-                message_retention_duration=message_retention_duration,
-            )
-        else:
-            subscription = pubsub_v1.types.Subscription(
-                name=subscription_path,
-                topic=topic_path,
-                message_retention_duration=message_retention_duration,
-            )
+            subscription_parameters["retry_policy"] = client_retry_policy
+
+        subscription = pubsub_v1.types.Subscription(subscription_parameters)
 
         update_mask = FieldMask(paths=mask_fields)
         self._client.update_subscription(

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -87,6 +87,7 @@ class TestSubscriber:
                 "ack_deadline_seconds": 60,
                 "name": expected_subscription,
                 "topic": expected_topic,
+                "message_retention_duration": "7d",
             }
         )
         assert subscriber._gc_project_id == "rele-test"
@@ -114,6 +115,7 @@ class TestSubscriber:
                 "ack_deadline_seconds": 100,
                 "name": expected_subscription,
                 "topic": expected_topic,
+                "message_retention_duration": "7d",
             }
         )
 
@@ -145,6 +147,7 @@ class TestSubscriber:
                 "name": expected_subscription,
                 "topic": expected_topic,
                 "filter": backend_filter_by,
+                "message_retention_duration": "7d",
             }
         )
 
@@ -190,6 +193,7 @@ class TestSubscriber:
                 "name": expected_subscription,
                 "topic": expected_topic,
                 "filter": backend_filter_by,
+                "message_retention_duration": "7d",
             }
         )
 
@@ -225,6 +229,7 @@ class TestSubscriber:
                 "name": expected_subscription,
                 "topic": expected_topic,
                 "retry_policy": expected_retry_policy,
+                "message_retention_duration": "7d",
             }
         )
 
@@ -267,6 +272,7 @@ class TestSubscriber:
                 "name": expected_subscription,
                 "topic": expected_topic,
                 "retry_policy": expected_retry_policy,
+                "message_retention_duration": "7d",
             }
         )
 

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -345,25 +345,6 @@ class TestSubscriber:
             request={"subscription": subscription, "update_mask": update_mask}
         )
 
-    # @patch.object(
-    #     SubscriberClient,
-    #     "create_subscription",
-    #     side_effect=exceptions.AlreadyExists("Subscription already exists"),
-    # )
-    # @patch.object(SubscriberClient, "update_subscription")
-    # def test_subscription_is_not_updated_when_exists_and_retry_policy_not_provided(
-    #     self,
-    #     client_update_subscription,
-    #     client_create_subscription,
-    #     project_id,
-    #     subscriber,
-    # ):
-    #     subscriber.update_or_create_subscription(
-    #         Subscription(None, topic=f"{project_id}-test-topic")
-    #     )
-
-    #     client_update_subscription.assert_not_called()
-
     @patch.object(
         SubscriberClient,
         "create_subscription",

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -67,6 +67,33 @@ class TestSubscriber:
 
     @patch.object(SubscriberClient, "create_subscription")
     @patch.object(SubscriberClient, "update_subscription")
+    def test_creates_subscription_with_default_message_retention_duration_when_provided(
+        self,
+        client_update_subscription,
+        client_create_subscription,
+        project_id,
+        subscriber,
+    ):
+        expected_subscription = (
+            f"projects/{project_id}/subscriptions/" f"{project_id}-test-topic"
+        )
+        expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
+        subscriber._message_retention_duration = "3d"
+        subscriber.update_or_create_subscription(
+            Subscription(None, topic=f"{project_id}-test-topic")
+        )
+        client_create_subscription.assert_called_once_with(
+            request={
+                "ack_deadline_seconds": 60,
+                "name": expected_subscription,
+                "topic": expected_topic,
+                "message_retention_duration": "3d",
+            }
+        )
+        assert subscriber._gc_project_id == "rele-test"
+
+    @patch.object(SubscriberClient, "create_subscription")
+    @patch.object(SubscriberClient, "update_subscription")
     def test_creates_subscription_with_default_ack_deadline_when_none_provided(
         self,
         client_update_subscription,

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -40,6 +40,33 @@ class TestSubscriber:
 
     @patch.object(SubscriberClient, "create_subscription")
     @patch.object(SubscriberClient, "update_subscription")
+    def test_creates_subscription_with_default_message_retention_duration_when_none_provided(
+        self,
+        client_update_subscription,
+        client_create_subscription,
+        project_id,
+        subscriber,
+    ):
+        expected_subscription = (
+            f"projects/{project_id}/subscriptions/" f"{project_id}-test-topic"
+        )
+        expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
+
+        subscriber.update_or_create_subscription(
+            Subscription(None, topic=f"{project_id}-test-topic")
+        )
+        client_create_subscription.assert_called_once_with(
+            request={
+                "ack_deadline_seconds": 60,
+                "name": expected_subscription,
+                "topic": expected_topic,
+                "message_retention_duration": "7d",
+            }
+        )
+        assert subscriber._gc_project_id == "rele-test"
+
+    @patch.object(SubscriberClient, "create_subscription")
+    @patch.object(SubscriberClient, "update_subscription")
     def test_creates_subscription_with_default_ack_deadline_when_none_provided(
         self,
         client_update_subscription,


### PR DESCRIPTION
### :tophat: What?

Set a default value for subscriptions message retention by default to 24 hours. You can set a custom value by specifying the parameter MESSAGE_RETENTION_DURATION in your Django project.

### :thinking: Why?

In [Google Pub/Sub pricing page](https://cloud.google.com/pubsub/pricing), they state that:

> Note: Starting from June 30, 2024, you are going to incur charges for retaining unacknowledged messages with subscriptions for more than 24 hours. If you are able to process the messages within 24 hours, the additional charges are not calculated. To know more, see [message retention duration](https://cloud.google.com/pubsub/docs/subscription-properties#message-retention-duration).

### :link: Related issue

Add related issue's number. Example: Fix #1
