### PR TITLE
Added build configurations to fix ReadTheDocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
### :tophat: What?
Added build configurations to fix ReadTheDocs build

### :thinking: Why?

ReadTheDocs build is failing because it do not find the build configurations.

![image](https://github.com/mercadona/rele/assets/10499839/85b55b34-6271-41c5-bcd8-f026a8b0619e)


### :link: Related issue
