### PR TITLE
Require at least pubsub 2.7.1

### DIFF
--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.15.0"
+__version__ = "1.15.1"
 
 try:
     import django

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     url="https://github.com/mercadona/rele",
     packages=find_packages(exclude=("tests",)),
     include_package_data=True,
-    install_requires=["google-auth", "google-cloud-pubsub>=2.2.0"],
+    install_requires=["google-auth", "google-cloud-pubsub>=2.7.1"],
     extras_require={"django": ["django", "tabulate"], "flask": ["flask"]},
     license="Apache Software License 2.0",
     zip_safe=False,


### PR DESCRIPTION
### :tophat: What?
- Require at least pubsub 2.7.1
Provide a description of what has been implemented.

### :thinking: Why?
- In version 2.7.1 https://github.com/googleapis/python-pubsub/releases/tag/v2.7.1 pytz is deprecated, we don't want to have this dependency as a requirement since is not necessary in upper versions.

### :link: Related issue

Add related issue's number. Example: Fix #1
