### PR TITLE
Revert "[Proposal] Perform a nack over the message when an exception is raised"

### DIFF
--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -143,7 +143,6 @@ class Callback:
                 start_time,
                 message,
             )
-            message.nack()
         else:
             message.ack()
             run_middleware_hook(

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -167,7 +167,6 @@ class TestCallback:
             request_queue=queue.Queue(),
         )
         message.ack = MagicMock(autospec=True)
-        message.nack = MagicMock(autospec=True)
         return message
 
     @pytest.fixture
@@ -274,8 +273,6 @@ class TestCallback:
 
         assert res is None
         message_wrapper.ack.assert_not_called()
-        message_wrapper.nack.assert_called_once()
-
         failed_log = caplog.records[-1]
         assert failed_log.message == (
             "Exception raised while processing "


### PR DESCRIPTION
Reverts mercadona/rele#254

Automatic ack could cause flooding in subscribers if they are not configured with an exponential backoff retry policy.