### PR TITLE
[Fixed] Wait until worker shutdown is complete

### DIFF
--- a/rele/worker.py
+++ b/rele/worker.py
@@ -140,6 +140,7 @@ class Worker:
         run_middleware_hook("pre_worker_stop", self._subscriptions)
         for future in self._futures.values():
             future.cancel()
+            future.result()
 
         run_middleware_hook("post_worker_stop")
         sys.exit(0)


### PR DESCRIPTION
### :tophat: What?

When shutting down workers, ensure proper termination by waiting until the future is complete (with `future.result()`).

This should fix a _spammy error_ we're getting on each shutdown:

> Observed terminating stream error Cancelled('Locally cancelled by application!')

This started happening in `google-cloud-pubsub==2.31.0` ([changelog](https://github.com/googleapis/python-pubsub/releases/tag/v2.31.0)), most probably due to the inclusion of [this fix](https://github.com/googleapis/python-pubsub/pull/1422).

### :thinking: Why?

`.result()` is expected to be called after `.cancel()` when shutting down, according to the [documentation](https://cloud.google.com/python/docs/reference/pubsub/latest/google.cloud.pubsub_v1.subscriber.client.Client#google_cloud_pubsub_v1_subscriber_client_Client_subscribe).

We're already following this approach when safely bootstrapping subscription consumers.

### :link: Related issue

N/A
