### PR TITLE
Fix graceful worker shutdown

### DIFF
--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.16.0b3"
+__version__ = "1.16.0b4"
 
 try:
     import django

--- a/rele/client.py
+++ b/rele/client.py
@@ -190,6 +190,10 @@ class Subscriber:
             subscription_path, callback=callback, scheduler=scheduler
         )
 
+    def close(self):
+        """Close the SubscriberClient."""
+        self._client.close()
+
 
 class Publisher:
     """The Publisher Class

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -113,6 +113,18 @@ class TestWorker:
 
         mock_wait_forever.assert_called_once()
 
+    @patch.object(Worker, "_wait_forever")
+    def test_stop_cancels_futures_and_closes_subscriber(
+        self, mock_wait_forever, mock_consume, mock_create_subscription, worker
+    ):
+        worker.run_forever()
+
+        with pytest.raises(SystemExit):
+            worker.stop()
+        
+        assert worker._futures[sub_stub]._state == FINISHED
+        assert worker._subscriber._client._closed is True
+
     @patch("rele.contrib.django_db_middleware.db.connections.close_all")
     def test_stop_closes_db_connections(self, mock_db_close_all, config, worker):
         config.middleware = ["rele.contrib.DjangoDBMiddleware"]


### PR DESCRIPTION
### :tophat: What?

Try to achieve a graceful shutdown of the `Worker` by ensuring that `SubscriberClient` is properly closed, as we're still getting `Cancelled` messages even with the changes introduced in #295.

### :thinking: Why?

As per `SubscriberClient` [documentation](https://cloud.google.com/python/docs/reference/pubsublite/latest/google.cloud.pubsublite.cloudpubsub.subscriber_client.SubscriberClient.html):

```
Must be used in a `with` block or have `__enter__()` called before use.
```

If we check the Python example provided in [StreamingPull and high-level client library code samples](https://cloud.google.com/pubsub/docs/pull#streamingpull_and_high-level_client_library_code_samples), we can see that the subscriber is expected to the wrapped in a `with` block to automatically call `close()` when done:

```python
# Wrap subscriber in a 'with' block to automatically call close() when done.
with subscriber:
    try:
        # When `timeout` is not set, result() will block indefinitely,
        # unless an exception is encountered first.
        streaming_pull_future.result(timeout=timeout)
    except TimeoutError:
        streaming_pull_future.cancel()  # Trigger the shutdown.
        streaming_pull_future.result()  # Block until the shutdown is complete.
```

### :link: Related issue

Add related issue's number. Example: Fix #1
