### PR TITLE
[Fixed] Avoid returning from finally in worker connection check

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,3 +16,4 @@ Thank you to all the contributors to Relé!
 * Chirag Jain (@chirgjin-les)
 * Jordi Chulia (@jorchube)
 * Emilio Carrión (@EmilioCarrion)
+* Miro (@Mirochill)

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -35,7 +35,7 @@ def check_internet_connection(remote_server):
         logger.exception("Check internet connection error", error)
     finally:
         sock.close()
-        return result
+    return result
 
 
 class Worker:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,3 +1,4 @@
+import socket
 import time
 from concurrent import futures
 from concurrent.futures._base import FINISHED
@@ -13,7 +14,7 @@ from rele import Subscriber, Worker, sub
 from rele.middleware import register_middleware
 from rele.retry_policy import RetryPolicy
 from rele.subscription import Callback
-from rele.worker import NotConnectionError, create_and_run
+from rele.worker import NotConnectionError, check_internet_connection, create_and_run
 
 
 @sub(topic="some-cool-topic", prefix="rele")
@@ -194,6 +195,27 @@ class TestWorker:
         mock_internet_connection.assert_called_once_with(
             "custom-api.interconnect.example.com"
         )
+
+
+class TestCheckInternetConnection:
+    @patch("rele.worker.socket.socket")
+    def test_closes_socket_after_success(self, mock_socket):
+        sock = mock_socket.return_value
+
+        assert check_internet_connection("example.com") is True
+
+        sock.settimeout.assert_called_once_with(5)
+        sock.connect.assert_called_once_with(("example.com", 80))
+        sock.close.assert_called_once_with()
+
+    @patch("rele.worker.socket.socket")
+    def test_closes_socket_after_connection_error(self, mock_socket):
+        sock = mock_socket.return_value
+        sock.connect.side_effect = socket.error
+
+        assert check_internet_connection("example.com") is False
+
+        sock.close.assert_called_once_with()
 
 
 @pytest.mark.usefixtures("mock_create_subscription")


### PR DESCRIPTION
### :tophat: What?

- Move `check_internet_connection()`'s `return result` outside the `finally` block so Python 3.14 no longer warns about `return` inside `finally`.
- Keep the socket close in `finally`.
- Add regression coverage for the success and socket-error paths.
- Add myself to `AUTHORS.md` as requested by `CONTRIBUTING.md`.

### :thinking: Why?

Returning from `finally` can mask exceptions raised in the `try` block, and Python 3.14 now emits a `SyntaxWarning` for this pattern. Returning after `finally` keeps the current boolean result while avoiding the warning.

Validation:
- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
- Not run locally

### :link: Related issue

Fix #299