### PR TITLE
[Fixed] Move return out of finally block in check_internet_connection

### DIFF
--- a/rele/worker.py
+++ b/rele/worker.py
@@ -35,7 +35,7 @@ def check_internet_connection(remote_server):
         logger.exception("Check internet connection error", error)
     finally:
         sock.close()
-        return result
+    return result
 
 
 class Worker:


### PR DESCRIPTION
## Description

Python 3.14 emits `SyntaxWarning: 'return' in a 'finally' block` for `rele/worker.py`. A `return` inside `finally` silently swallows any in-flight exception, which is why Python now warns about the pattern.

All exceptions in `check_internet_connection` are already handled by the `except` clause, so moving the `return` after the `try/finally` preserves the existing behavior exactly while removing the warning.

This is the only occurrence of the pattern in the codebase (verified with an AST scan for `return`/`break`/`continue` inside `finally` blocks).

Fixes #299

## Testing

`python runtests.py tests` — 102 passed.

Generated with Claude Code