### PR TITLE
[Changed] Require Python >= 3.10 and support up to Python 3.14

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,12 +8,12 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@
 import os
 import sys
 
-
 sys.path.insert(0, os.path.abspath(".."))
 
 import rele  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "Mercadona Tech", email = "software.online@mercadona.es" },
 ]
 license = { text = "Apache Software License 2.0" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = ["rele"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -23,11 +23,11 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "google-auth",
@@ -54,7 +54,6 @@ include = ["rele*"]
 
 [tool.black]
 line-length = 88
-target_version = ['py36']
 include = '\.pyi?$'
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ include = ["rele*"]
 
 [tool.black]
 line-length = 88
+target-version = ["py310", "py311", "py312", "py313", "py314"]
 include = '\.pyi?$'
 
 [tool.isort]

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,9 +1,9 @@
-pytest==7.3.1
+pytest==8.4.2
 pytest-cov>=2.7.0
-pytest-django>=3.5
+pytest-django>=4.5
 coverage>=4.4.0
 codecov>=2.0.0
-black==24.8.0
-isort~=5.10.0
-freezegun==1.4.0
+black==26.5.1
+isort~=6.1.0
+freezegun==1.5.5
 tests/sample_pypi_package

--- a/tests/commands/test_showsubscriptions.py
+++ b/tests/commands/test_showsubscriptions.py
@@ -45,13 +45,10 @@ class TestShowSubscriptions:
 
         mock_discover_subs.assert_called_once()
         captured = capfd.readouterr()
-        assert (
-            captured.out
-            == """Topic                Subscriber(s)         Sub
+        assert captured.out == """Topic                Subscriber(s)         Sub
 -------------------  --------------------  ----------------------------
 photo-updated        photo-updated         sub_process_landscape_photos
 published-time-type  published-time-type   sub_published_time_type
 some-cool-topic      rele-some-cool-topic  sub_stub
 some-fancy-topic     some-fancy-topic      sub_fancy_stub
 """
-        )

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -12,6 +12,7 @@ class TestPublish:
     def test_instantiates_publisher_and_publishes_when_does_not_exist(
         self, mock_publisher
     ):
+        publishing._publisher = None
         with patch("rele.publishing.discover") as mock_discover:
             mock_discover.sub_modules.return_value = settings, []
 


### PR DESCRIPTION
## Description

Closes #305 (part of #304).

Python 3.8 and 3.9 are past end-of-life, and `google-cloud-pubsub` itself already dropped them upstream (2.39.0 supports 3.10–3.14 only), so users on old Pythons were frozen on stale dependencies anyway.

- `requires-python` raised to `>=3.10`; classifiers now declare 3.10–3.14.
- CI matrix moves from 3.8–3.12 to **3.10–3.14** (`actions/checkout@v4` + `actions/setup-python@v5` bumped for 3.14 support).
- Test pins refreshed now that 3.8/3.9 no longer constrain them: pytest 7.3.1 → 8.4.2, black 24.8.0 → 26.5.1, isort 5.10 → 6.1, freezegun 1.4.0 → 1.5.5.
- black `target-version` set explicitly to py310–py314: black 26 otherwise infers targets from `requires-python` including future releases (py315), making its AST safety check depend on which interpreter runs the lint.
- Two side effects handled in their own commits:
  - **pytest 8 exposed an order-dependent test**: `test_instantiates_publisher_and_publishes_when_does_not_exist` never reset the global publisher singleton (its sibling tests do). One-line precondition fix.
  - Mechanical reformat of 2 files for black 26.

Note: the 3.14 `SyntaxWarning` blocker was already fixed in #303.

## Testing

Full suite (102 tests) run locally on **3.10, 3.12 and 3.14**: all green. `black --check` verified to produce identical results under 3.10, 3.12 and 3.14; `isort --check-only` green.

Heads-up: #311 (flaky worker test racing a real Pub/Sub connection) can still redden any matrix job — rerun if it bites.

Generated with Claude Code