### PR TITLE
[Changed] Switch build backend to hatchling with SPDX license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "rele"
@@ -10,7 +10,8 @@ readme = "README.md"
 authors = [
     { name = "Mercadona Tech", email = "software.online@mercadona.es" },
 ]
-license = { text = "Apache Software License 2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE", "AUTHORS.md"]
 requires-python = ">=3.10"
 keywords = ["rele"]
 classifiers = [
@@ -20,7 +21,6 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
@@ -46,11 +46,11 @@ Homepage = "https://github.com/mercadona/rele"
 Documentation = "https://mercadonarele.readthedocs.io"
 Changelog = "https://github.com/mercadona/rele/blob/master/CHANGELOG.rst"
 
-[tool.setuptools.dynamic]
-version = { attr = "rele.__version__" }
+[tool.hatch.version]
+path = "rele/__init__.py"
 
-[tool.setuptools.packages.find]
-include = ["rele*"]
+[tool.hatch.build.targets.wheel]
+packages = ["rele"]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Description

Part of #304. **Stacked on #312** — it needs `requires-python >= 3.10` for PEP 639 support, so the base branch is `feature/python-310-minimum`; when #312 merges, this PR retargets to `master` automatically. Review only the last commit.

- Build backend: setuptools → **hatchling**. Version stays single-sourced from `rele/__init__.py` via `[tool.hatch.version]`.
- License declared as SPDX expression (`Apache-2.0`, PEP 639) with explicit `license-files`; the deprecated `License :: OSI Approved` classifier is removed. The wheel METADATA now carries `License-Expression: Apache-2.0`.
- `Makefile`/`requirements/deploy.txt` need no changes: `python -m build` is backend-agnostic.

## Testing

- Wheel comparison against the setuptools build from the base branch: **identical file-by-file** except `top_level.txt`, a setuptools-specific legacy file no standard requires (28 files + dist-info, licenses `LICENSE`/`AUTHORS.md` preserved, `entry_points.txt` intact).
- `twine check` passes on sdist and wheel.
- Smoke test on Python 3.14: `pip install rele[django]` from the built wheel, `import rele` and `rele-cli --help` work.

Generated with Claude Code