### PR TITLE
[Changed] Replace black and isort with ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,12 @@ install: ## install the project and every dependency group
 	uv sync --all-groups --all-extras
 
 lint: ## check for coding style issues
-	uv run black . --check --diff
-	uv run isort . --check-only
+	uv run ruff check .
+	uv run ruff format --check .
 
 lint-fix: ## try to automagically fix coding style issues
-	uv run black .
-	uv run isort .
+	uv run ruff check --fix .
+	uv run ruff format .
 
 test: ## run tests quickly with the default Python
 	uv run python runtests.py tests

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(".."))
 
-import rele  # noqa
+import rele
 
 # -- Project information -----------------------------------------------------
 
@@ -51,7 +51,7 @@ html_theme_options = {
     "font_family": "Heebo",
     "logo_name": False,
     "code_font_family": (
-        '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,' " monospace"
+        '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace'
     ),
     "code_font_size": "0.8em",
     "show_related": False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,7 @@ test = [
     "pytest-django>=4.5",
     "coverage>=4.4.0",
     "codecov>=2.0.0",
-    "black==26.5.1",
-    "isort~=6.1.0",
+    "ruff==0.15.22",
     "freezegun==1.5.5",
     "django",
     "tabulate",
@@ -75,19 +74,18 @@ path = "rele/__init__.py"
 [tool.hatch.build.targets.wheel]
 packages = ["rele"]
 
-[tool.black]
+[tool.ruff]
 line-length = 88
-target-version = ["py310", "py311", "py312", "py313", "py314"]
-include = '\.pyi?$'
+exclude = [".git", "__pycache__"]
 
-[tool.isort]
-line_length = 90
-default_section = "THIRDPARTY"
-known_first_party = ["rele"]
-multi_line_output = 3
-use_parentheses = true
-include_trailing_comma = true
-skip = ["docs", ".venv"]
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "C4", "C90", "UP", "B", "N", "RUF"]
+ignore = []
+fixable = ["ALL"]
+unfixable = []
+
+[tool.ruff.lint.extend-per-file-ignores]
+"tests/*" = ["E501"]
 
 [tool.coverage.run]
 include = ["*"]

--- a/rele/client.py
+++ b/rele/client.py
@@ -112,8 +112,10 @@ class Subscriber:
         if isinstance(policy, str):
             # Warning log for future compatibility
             warnings.warn(
-                "`message_storage_policy` as a string is deprecated. Use a list of regions instead.",
+                "`message_storage_policy` as a string is deprecated. "
+                "Use a list of regions instead.",
                 DeprecationWarning,
+                stacklevel=2,
             )
             return [policy]
         if isinstance(policy, list):
@@ -123,7 +125,8 @@ class Subscriber:
         if policy is None:
             return policy
         raise TypeError(
-            "`message_storage_policy` must be None or either a string or a list of regions."
+            "`message_storage_policy` must be None or either a string "
+            "or a list of regions."
         )
 
     def _create_subscription(self, subscription_path, topic_path, subscription):
@@ -180,8 +183,13 @@ class Subscriber:
 
         :param subscription_name: str Subscription name
         :param callback: Function which act on a topic message
-        :param scheduler: `Thread pool-based scheduler. <https://googleapis.dev/python/pubsub/latest/subscriber/api/scheduler.html?highlight=threadscheduler#google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler>`_  # noqa
-        :return: `Future <https://googleapis.github.io/google-cloud-python/latest/pubsub/subscriber/api/futures.html>`_  # noqa
+        :param scheduler: `Thread pool-based scheduler`_
+        :return: `Future`_
+
+        .. _Thread pool-based scheduler:
+           https://googleapis.dev/python/pubsub/latest/subscriber/api/scheduler.html
+        .. _Future:
+           https://googleapis.dev/python/pubsub/latest/subscriber/api/futures.html
         """
         subscription_path = self._client.subscription_path(
             self._gc_project_id, subscription_name
@@ -209,9 +217,11 @@ class Publisher:
 
     :param gc_project_id: string Google Cloud Project ID.
     :param credentials: string Google Cloud Credentials.
-    :param encoder: A valid `json.encoder.JSONEncoder subclass <https://docs.python.org/3/library/json.html#json.JSONEncoder>`_  # noqa
+    :param encoder: A valid `json.encoder.JSONEncoder subclass
+        <https://docs.python.org/3/library/json.html#json.JSONEncoder>`_
     :param timeout: float, default :ref:`settings_publisher_timeout`
-    :param blocking: boolean, default None falls back to :ref:`settings_publisher_blocking`
+    :param blocking: boolean, default None falls back to
+        :ref:`settings_publisher_blocking`
     """
 
     def __init__(
@@ -253,7 +263,9 @@ class Publisher:
         Usage::
 
             publisher = Publisher()
-            future = publisher.publish('topic_name', {'foo': 'bar'}, blocking=True, timeout=10.0) # noqa
+            future = publisher.publish(
+                'topic_name', {'foo': 'bar'}, blocking=True, timeout=10.0
+            )
 
         However, it should be noted that using `blocking=True` may incur a
         significant performance hit.
@@ -264,11 +276,17 @@ class Publisher:
 
         :param topic: string topic to publish the data.
         :param data: dict with the content of the message.
-        :param blocking: boolean, default None falls back to :ref:`settings_publisher_blocking`
-        :param timeout: float, default None falls back to :ref:`settings_publisher_timeout`
-        :param raise_exception: boolean. If True, exceptions coming from PubSub will be raised
+        :param blocking: boolean, default None falls back to
+            :ref:`settings_publisher_blocking`
+        :param timeout: float, default None falls back to
+            :ref:`settings_publisher_timeout`
+        :param raise_exception: boolean. If True, exceptions coming from
+            PubSub will be raised
         :param attrs: additional string parameters to be published.
-        :return: `Future <https://googleapis.github.io/google-cloud-python/latest/pubsub/subscriber/api/futures.html>`_  # noqa
+        :return: `Future`_
+
+        .. _Future:
+           https://googleapis.dev/python/pubsub/latest/subscriber/api/futures.html
         """
         if blocking is None:
             blocking = self._blocking

--- a/rele/config.py
+++ b/rele/config.py
@@ -131,11 +131,12 @@ def load_subscriptions_from_paths(sub_module_paths, sub_prefix=None, filter_by=N
                 continue
 
             if subscription.name in subscriptions:
-                found_subscription = subscriptions[subscription.name]
+                found_func = subscriptions[subscription.name]._func
+                func = subscription._func
                 raise RuntimeError(
-                    f"Duplicate subscription name found: {subscription.name}. Subs "
-                    f"{subscription._func.__module__}.{subscription._func.__name__} and "
-                    f"{found_subscription._func.__module__}.{found_subscription._func.__name__} collide."
+                    f"Duplicate subscription name found: {subscription.name}. "
+                    f"Subs {func.__module__}.{func.__name__} and "
+                    f"{found_func.__module__}.{found_func.__name__} collide."
                 )
 
             subscriptions[subscription.name] = subscription

--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -65,7 +65,7 @@ class LoggingMiddleware(BaseMiddleware):
     def post_publish_failure(self, topic, exception, message):
         self._logger.exception(
             f"Exception raised while publishing message "
-            f"for {topic}: {str(exception.__class__.__name__)}",
+            f"for {topic}: {exception.__class__.__name__!s}",
             exc_info=True,
             extra={
                 "metrics": {
@@ -105,7 +105,7 @@ class LoggingMiddleware(BaseMiddleware):
     ):
         self._logger.error(
             f"Exception raised while processing message "
-            f"for {subscription}: {str(exception.__class__.__name__)}",
+            f"for {subscription}: {exception.__class__.__name__!s}",
             exc_info=True,
             extra={
                 "metrics": {

--- a/rele/contrib/unrecoverable_middleware.py
+++ b/rele/contrib/unrecoverable_middleware.py
@@ -1,7 +1,7 @@
 from rele.middleware import BaseMiddleware
 
 
-class UnrecoverableException(Exception):
+class UnrecoverableException(Exception):  # noqa: N818 -- renaming would break the public API
     pass
 
 

--- a/rele/contrib/verbose_logging_middleware.py
+++ b/rele/contrib/verbose_logging_middleware.py
@@ -49,7 +49,7 @@ class _VerboseMessage:
         self.attributes = message.attributes
 
     def __repr__(self):
-        _MESSAGE_REPR = """\
+        message_repr = """\
 Message {{
   data: {!r}
   ordering_key: {!r}
@@ -60,7 +60,7 @@ Message {{
         attrs = self._message_attrs_repr()
         ordering_key = str(self._message.ordering_key)
 
-        return _MESSAGE_REPR.format(data, ordering_key, attrs)
+        return message_repr.format(data, ordering_key, attrs)
 
     def _message_attrs_repr(self):
         message_attrs = json.dumps(

--- a/rele/discover.py
+++ b/rele/discover.py
@@ -25,7 +25,7 @@ def module_has_submodule(package, module_name):
 
 def _import_settings_from_path(path):
     if path is not None:
-        print(" * Discovered settings: %r" % path)
+        print(f" * Discovered settings: {path!r}")
         return importlib.import_module(path)
 
 
@@ -41,13 +41,13 @@ def sub_modules(settings_path=None):
     :return: (settings module, List[string: subs module paths])
     """
     module_paths = []
-    for f, package, is_package in pkgutil.walk_packages(path=["."]):
+    for _, package, is_package in pkgutil.walk_packages(path=["."]):
         if package == "settings":
             settings_path = package
         if is_package and module_has_submodule(package, "subs"):
             module = package + ".subs"
             module_paths.append(module)
-            print(" * Discovered subs module: %r" % module)
+            print(f" * Discovered subs module: {module!r}")
 
     settings = _import_settings_from_path(settings_path)
     return settings, module_paths

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
     config = config.Config(settings.RELE)
 
     def handle(self, *args, **options):
-        if all(map(lambda x: x.get("CONN_MAX_AGE"), settings.DATABASES.values())):
+        if all(x.get("CONN_MAX_AGE") for x in settings.DATABASES.values()):
             self.stderr.write(
                 self.style.WARNING(
                     "WARNING: settings.CONN_MAX_AGE is not set to 0. "
@@ -26,5 +26,5 @@ class Command(BaseCommand):
         subs = config.load_subscriptions_from_paths(
             discover_subs_modules(), self.config.sub_prefix, self.config.filter_by
         )
-        self.stdout.write(f"Configuring worker with {len(subs)} " f"subscription(s)...")
+        self.stdout.write(f"Configuring worker with {len(subs)} subscription(s)...")
         create_and_run(subs, self.config)

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -36,6 +36,7 @@ class WarnDeprecatedHooks(type):
                     "and will be removed in future versions. Please substitute it with "
                     "the post_publish_success hook instead.",
                     DeprecationWarning,
+                    stacklevel=2,
                 )
         return x
 

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -216,8 +216,9 @@ def sub(
         args_spec = getfullargspec(func)
         if len(args_spec.args) != 1 or not args_spec.varkw:
             raise RuntimeError(
-                f"Subscription function {func.__module__}.{func.__name__} is not valid. "
-                "The function must have one argument and accept keyword arguments."
+                f"Subscription function {func.__module__}.{func.__name__} "
+                "is not valid. The function must have one argument and "
+                "accept keyword arguments."
             )
 
         if getmodule(func).__name__.split(".")[-1] != "subs":

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -5,7 +5,6 @@ import sys
 import time
 from concurrent import futures
 from datetime import datetime
-from typing import Dict
 
 from google.cloud.pubsub_v1.futures import Future
 from google.cloud.pubsub_v1.subscriber.scheduler import ThreadScheduler
@@ -31,7 +30,7 @@ def check_internet_connection(remote_server):
     try:
         sock.connect((remote_server, port))
         result = True
-    except (socket.error, socket.herror, socket.gaierror, socket.timeout) as error:
+    except (TimeoutError, OSError, socket.herror, socket.gaierror) as error:
         logger.exception("Check internet connection error", error)
     finally:
         sock.close()
@@ -66,7 +65,7 @@ class Worker:
             default_ack_deadline,
             default_retry_policy,
         )
-        self._futures: Dict[str, Future] = {}
+        self._futures: dict[str, Future] = {}
         self._subscriptions = subscriptions
         self.threads_per_subscription = threads_per_subscription
         self.internet_check_endpoint = self._get_internet_check_endpoint(client_options)
@@ -85,10 +84,10 @@ class Worker:
         If the subscription already exists, the subscription will not be
         re-created. Therefore, it is idempotent.
         """
-        logger.debug(f"[start] start setup")
+        logger.debug("[start] start setup")
         for subscription in self._subscriptions:
             self._subscriber.update_or_create_subscription(subscription)
-        logger.debug(f"[setup] end setup")
+        logger.debug("[setup] end setup")
 
     def start(self):
         """Begin consuming all subscriptions.
@@ -100,25 +99,25 @@ class Worker:
         The futures are stored so that they can be cancelled later on
         for a graceful shutdown of the worker.
         """
-        logger.debug(f"[start] start start")
+        logger.debug("[start] start start")
         run_middleware_hook("pre_worker_start")
         for subscription in self._subscriptions:
             self._boostrap_consumption(subscription)
         run_middleware_hook("post_worker_start")
-        logger.debug(f"[start] end start")
+        logger.debug("[start] end start")
 
     def run_forever(self, sleep_interval=1):
         """Shortcut for calling setup, start, and _wait_forever.
 
         :param sleep_interval: Number of seconds to sleep in the ``while True`` loop
         """
-        logger.debug(f"[run_forever] setup")
+        logger.debug("[run_forever] setup")
         self.setup()
-        logger.debug(f"[run_forever] start")
+        logger.debug("[run_forever] start")
         self.start()
-        logger.debug(f"[run_forever] wait for ever")
+        logger.debug("[run_forever] wait for ever")
         self._wait_forever(sleep_interval=sleep_interval)
-        logger.debug(f"[run_forever] finish")
+        logger.debug("[run_forever] finish")
 
     def stop(self, signal=None, frame=None):
         """Manage the shutdown process of the worker.
@@ -134,23 +133,25 @@ class Worker:
 
         Exits with code 0 for a clean exit.
 
-        :param signal: Needed for `signal.signal <https://docs.python.org/3/library/signal.html#signal.signal>`_  # noqa
-        :param frame: Needed for `signal.signal <https://docs.python.org/3/library/signal.html#signal.signal>`_  # noqa
+        :param signal: Needed for `signal.signal
+            <https://docs.python.org/3/library/signal.html#signal.signal>`_
+        :param frame: Needed for `signal.signal
+            <https://docs.python.org/3/library/signal.html#signal.signal>`_
         """
         run_middleware_hook("pre_worker_stop", self._subscriptions)
-        logger.debug(f"[stop] cancel all futures")
+        logger.debug("[stop] cancel all futures")
         for future in self._futures.values():
             future.cancel()
             future.result()
 
-        logger.debug(f"[stop] close subscriber")
+        logger.debug("[stop] close subscriber")
         self._subscriber.close()
 
         run_middleware_hook("post_worker_stop")
         sys.exit(0)
 
     def _boostrap_consumption(self, subscription):
-        logger.debug(f"[_boostrap_consumption][0] " f"subscription {subscription.name}")
+        logger.debug(f"[_boostrap_consumption][0] subscription {subscription.name}")
 
         if subscription in self._futures:
             logger.debug(
@@ -243,7 +244,7 @@ def create_and_run(subs, config):
     :param subs: List :class:`~rele.subscription.Subscription`
     :param config: :class:`~rele.config.Config`
     """
-    logger.debug(f"" f"Configuring worker with {len(subs)} subscription(s)...")
+    logger.debug(f"Configuring worker with {len(subs)} subscription(s)...")
     for sub in subs:
         print(f"Subscription: {sub}")
     worker = Worker(

--- a/runtests.py
+++ b/runtests.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8
-from __future__ import absolute_import, unicode_literals
 
 import os
 import sys
@@ -11,7 +9,7 @@ import django
 from rele.apps import ReleConfig
 
 
-class PytestTestRunner(object):
+class PytestTestRunner:
     """Runs pytest to discover and run tests."""
 
     def __init__(self, verbosity=1, failfast=False, keepdb=False, **kwargs):

--- a/tests/commands/test_runrele.py
+++ b/tests/commands/test_runrele.py
@@ -35,7 +35,7 @@ class TestRunReleCommand:
         settings.DATABASES = {"default": {"CONN_MAX_AGE": 1}}
         call_command("runrele")
 
-        out, err = capsys.readouterr()
+        _, err = capsys.readouterr()
         assert (
             "WARNING: settings.CONN_MAX_AGE is not set to 0. "
             "This may result in slots for database connections to "

--- a/tests/commands/test_showsubscriptions.py
+++ b/tests/commands/test_showsubscriptions.py
@@ -18,7 +18,7 @@ def sub_fancy_stub(data, **kwargs):
 
 @sub(topic="published-time-type")
 def sub_published_time_type(data, **kwargs):
-    return f'{type(kwargs["published_at"])}'
+    return f"{type(kwargs['published_at'])}"
 
 
 def landscape_filter(**kwargs):
@@ -27,14 +27,12 @@ def landscape_filter(**kwargs):
 
 @sub(topic="photo-updated", filter_by=landscape_filter)
 def sub_process_landscape_photos(data, **kwargs):
-    return f'Received a photo of type {kwargs.get("type")}'
+    return f"Received a photo of type {kwargs.get('type')}"
 
 
 @pytest.fixture()
 def mock_discover_subs():
-    affected_path = (
-        "rele.management.commands.showsubscriptions" ".discover_subs_modules"
-    )
+    affected_path = "rele.management.commands.showsubscriptions.discover_subs_modules"
     with patch(affected_path, return_value=[__name__]) as mock:
         yield mock
 
@@ -45,10 +43,13 @@ class TestShowSubscriptions:
 
         mock_discover_subs.assert_called_once()
         captured = capfd.readouterr()
-        assert captured.out == """Topic                Subscriber(s)         Sub
+        assert (
+            captured.out
+            == """Topic                Subscriber(s)         Sub
 -------------------  --------------------  ----------------------------
 photo-updated        photo-updated         sub_process_landscape_photos
 published-time-type  published-time-type   sub_published_time_type
 some-cool-topic      rele-some-cool-topic  sub_stub
 some-fancy-topic     some-fancy-topic      sub_fancy_stub
 """
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from google.cloud.pubsub_v1 import PublisherClient
 from google.cloud.pubsub_v1.exceptions import TimeoutError
 from google.protobuf import timestamp_pb2
 
-from rele import Publisher, Worker
+from rele import Publisher
 from rele.client import Subscriber
 from rele.config import Config
 from rele.middleware import register_middleware

--- a/tests/contrib/test_logging_middleware.py
+++ b/tests/contrib/test_logging_middleware.py
@@ -28,7 +28,7 @@ def expected_message_data_log_with_decimal():
 @pytest.fixture
 def message_wrapper(published_at, publish_time):
     rele_message = pubsub_v1.types.PubsubMessage(
-        data='{"foo": "bar"}'.encode("utf-8"),
+        data=b'{"foo": "bar"}',
         attributes={"lang": "es", "published_at": str(published_at)},
         message_id="1",
         publish_time=publish_time,
@@ -130,6 +130,6 @@ class TestLoggingMiddleware:
         post_publish_failure_message_log = caplog.records[0].subscription_message
         post_process_message_message_log = caplog.records[1].subscription_message
 
-        assert type(post_publish_failure_message_log) == type(
+        assert type(post_publish_failure_message_log) is type(
             post_process_message_message_log
         )

--- a/tests/contrib/test_verbose_logging_middleware.py
+++ b/tests/contrib/test_verbose_logging_middleware.py
@@ -34,7 +34,7 @@ def long_message_wrapper(published_at, publish_time):
 @pytest.fixture
 def message_wrapper(published_at, publish_time):
     rele_message = pubsub_v1.types.PubsubMessage(
-        data="ABCDE".encode("utf-8"),
+        data=b"ABCDE",
         attributes={"lang": "es", "published_at": str(published_at)},
         message_id="1",
         publish_time=publish_time,
@@ -57,7 +57,7 @@ def expected_message_log():
 
 class TestVerboseLoggingMiddleware:
     @pytest.fixture
-    def config(project_id):
+    def config(self):
         return Config(
             {
                 "APP_NAME": "rele",

--- a/tests/sample_app/infrastructure/subs/__init__.py
+++ b/tests/sample_app/infrastructure/subs/__init__.py
@@ -1,1 +1,1 @@
-from .a_sub_file import sub_inside_infra_module
+from .a_sub_file import sub_inside_infra_module as sub_inside_infra_module

--- a/tests/sample_app_2/infrastructure/subs/__init__.py
+++ b/tests/sample_app_2/infrastructure/subs/__init__.py
@@ -1,1 +1,1 @@
-from .a_sub_file import sub_inside_a_module
+from .a_sub_file import sub_inside_a_module as sub_inside_a_module

--- a/tests/sample_app_2/subs/__init__.py
+++ b/tests/sample_app_2/subs/__init__.py
@@ -1,1 +1,1 @@
-from .another_sub_file import sub_inside_a_module
+from .another_sub_file import sub_inside_a_module as sub_inside_a_module

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 from logging import config as logging_config
 

--- a/tests/subs.py
+++ b/tests/subs.py
@@ -17,7 +17,7 @@ class ClassBasedSub(Subscription):
         return data["id"]
 
 
-class CustomException(Exception):
+class CustomError(Exception):
     pass
 
 

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -1,9 +1,8 @@
-from unittest.mock import ANY, MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
 from rele import Publisher, publishing
-from rele.config import Config
 from tests import settings
 
 

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -48,9 +48,9 @@ class TestSubscriber:
         subscriber,
     ):
         expected_subscription = (
-            f"projects/{project_id}/subscriptions/" f"{project_id}-test-topic"
+            f"projects/{project_id}/subscriptions/{project_id}-test-topic"
         )
-        expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
+        expected_topic = f"projects/{project_id}/topics/{project_id}-test-topic"
 
         subscriber.update_or_create_subscription(
             Subscription(None, topic=f"{project_id}-test-topic")
@@ -74,9 +74,9 @@ class TestSubscriber:
         subscriber,
     ):
         expected_subscription = (
-            f"projects/{project_id}/subscriptions/" f"{project_id}-test-topic"
+            f"projects/{project_id}/subscriptions/{project_id}-test-topic"
         )
-        expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
+        expected_topic = f"projects/{project_id}/topics/{project_id}-test-topic"
         subscriber._ack_deadline = 100
         subscriber.update_or_create_subscription(
             Subscription(None, topic=f"{project_id}-test-topic")
@@ -100,9 +100,9 @@ class TestSubscriber:
         subscriber,
     ):
         expected_subscription = (
-            f"projects/{project_id}/subscriptions/" f"{project_id}-test-topic"
+            f"projects/{project_id}/subscriptions/{project_id}-test-topic"
         )
-        expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
+        expected_topic = f"projects/{project_id}/topics/{project_id}-test-topic"
         backend_filter_by = "attributes:domain"
         subscriber.update_or_create_subscription(
             Subscription(
@@ -136,9 +136,9 @@ class TestSubscriber:
         mock_create_topic,
     ):
         expected_subscription = (
-            f"projects/{project_id}/subscriptions/" f"{project_id}-test-topic"
+            f"projects/{project_id}/subscriptions/{project_id}-test-topic"
         )
-        expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
+        expected_topic = f"projects/{project_id}/topics/{project_id}-test-topic"
         backend_filter_by = "attributes:domain"
         subscriber.update_or_create_subscription(
             Subscription(
@@ -181,9 +181,9 @@ class TestSubscriber:
         mock_create_topic,
     ):
         expected_subscription = (
-            f"projects/{project_id}/subscriptions/" f"{project_id}-test-topic"
+            f"projects/{project_id}/subscriptions/{project_id}-test-topic"
         )
-        expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
+        expected_topic = f"projects/{project_id}/topics/{project_id}-test-topic"
         backend_filter_by = "attributes:domain"
         subscriber_with_multiple_storage_regions.update_or_create_subscription(
             Subscription(
@@ -221,9 +221,9 @@ class TestSubscriber:
         subscriber,
     ):
         expected_subscription = (
-            f"projects/{project_id}/subscriptions/" f"{project_id}-test-topic"
+            f"projects/{project_id}/subscriptions/{project_id}-test-topic"
         )
-        expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
+        expected_topic = f"projects/{project_id}/topics/{project_id}-test-topic"
         expected_retry_policy = pubsub_v1.types.RetryPolicy(
             minimum_backoff=duration_pb2.Duration(seconds=10),
             maximum_backoff=duration_pb2.Duration(seconds=50),
@@ -264,9 +264,9 @@ class TestSubscriber:
             config_with_retry_policy.retry_policy,
         )
         expected_subscription = (
-            f"projects/{project_id}/subscriptions/" f"{project_id}-test-topic"
+            f"projects/{project_id}/subscriptions/{project_id}-test-topic"
         )
-        expected_topic = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
+        expected_topic = f"projects/{project_id}/topics/{project_id}-test-topic"
         expected_retry_policy = pubsub_v1.types.RetryPolicy(
             minimum_backoff=duration_pb2.Duration(seconds=5),
             maximum_backoff=duration_pb2.Duration(seconds=30),
@@ -302,9 +302,9 @@ class TestSubscriber:
         subscriber,
     ):
         subscription_path = (
-            f"projects/{project_id}/subscriptions/" f"{project_id}-test-topic"
+            f"projects/{project_id}/subscriptions/{project_id}-test-topic"
         )
-        topic_path = f"projects/{project_id}/topics/" f"{project_id}-test-topic"
+        topic_path = f"projects/{project_id}/topics/{project_id}-test-topic"
         retry_policy = pubsub_v1.types.RetryPolicy(
             minimum_backoff=duration_pb2.Duration(seconds=10),
             maximum_backoff=duration_pb2.Duration(seconds=50),

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -16,22 +16,22 @@ logger = logging.getLogger(__name__)
 
 @sub(topic="some-cool-topic", prefix="rele")
 def sub_stub(data, **kwargs):
-    logger.info(f'I am a task doing stuff with ID {data["id"]} ' f'({kwargs["lang"]})')
+    logger.info(f"I am a task doing stuff with ID {data['id']} ({kwargs['lang']})")
     return data["id"]
 
 
 @sub(topic="some-fancy-topic")
 def sub_fancy_stub(data, **kwargs):
     logger.info(
-        f'I used to have a prefix, but not anymore, only {data["id"]}'
-        f'id {kwargs["lang"]}'
+        f"I used to have a prefix, but not anymore, only {data['id']}"
+        f"id {kwargs['lang']}"
     )
     return data["id"]
 
 
 @sub(topic="published-time-type")
 def sub_published_time_type(data, **kwargs):
-    logger.info(f'{type(kwargs["published_at"])}')
+    logger.info(f"{type(kwargs['published_at'])}")
 
 
 def landscape_filter(kwargs):
@@ -44,12 +44,12 @@ def gif_filter(kwargs):
 
 @sub(topic="photo-updated", filter_by=landscape_filter)
 def sub_process_landscape_photos(data, **kwargs):
-    return f'Received a photo of type {kwargs.get("type")}'
+    return f"Received a photo of type {kwargs.get('type')}"
 
 
 @sub(topic="photo-updated", filter_by=[landscape_filter, gif_filter])
 def sub_process_landscape_gif_photos(data, **kwargs):
-    return f'Received a {kwargs.get("format")} photo of type {kwargs.get("type")}'
+    return f"Received a {kwargs.get('format')} photo of type {kwargs.get('type')}"
 
 
 class TestSubscription:
@@ -137,7 +137,7 @@ class TestCallback:
     @pytest.fixture(autouse=True)
     def mock_close_old_connections(self):
         with patch(
-            "rele.contrib.django_db_middleware.db." "close_old_connections"
+            "rele.contrib.django_db_middleware.db.close_old_connections"
         ) as mock_old_connections:
             yield mock_old_connections
 
@@ -207,7 +207,7 @@ class TestCallback:
         assert res == 123
         log1 = caplog.records[0]
         assert log1.message == (
-            "Start processing message for " "rele-some-cool-topic - sub_stub"
+            "Start processing message for rele-some-cool-topic - sub_stub"
         )
         assert log1.metrics == {
             "name": "subscriptions",
@@ -233,7 +233,7 @@ class TestCallback:
         assert len(caplog.records) == 3
         message_wrapper_log = caplog.records[1]
         assert message_wrapper_log.message == (
-            "I am a task doing " "stuff with ID 123 (es)"
+            "I am a task doing stuff with ID 123 (es)"
         )
 
     def test_log_when_execution_is_succesful(
@@ -244,7 +244,7 @@ class TestCallback:
 
         success_log = caplog.records[-1]
         assert success_log.message == (
-            "Successfully processed message for " "rele-some-cool-topic - sub_stub"
+            "Successfully processed message for rele-some-cool-topic - sub_stub"
         )
         assert success_log.metrics == {
             "name": "subscriptions",

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -269,7 +269,7 @@ class TestRestartConsumer:
         mock_internet_connection.assert_not_called()
 
     @freeze_time("2024-01-01 10:00:50Z")
-    def test_raises_not_connection_error_during_wait_forever_if_connection_is_down_every_50_seconds(  # noqa
+    def test_raises_not_connection_error_during_wait_forever_if_connection_is_down_every_50_seconds(
         self, worker, mock_internet_connection
     ):
         mock_internet_connection.return_value = False

--- a/uv.lock
+++ b/uv.lock
@@ -49,50 +49,6 @@ wheels = [
 ]
 
 [[package]]
-name = "black"
-version = "26.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/84/b3f55026206a9e8820a91503308075ca48eadc515e436731ca01dbe043b3/black-26.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9942db8888e06943c5dde66ca0037dcff82a2a4ec1ad0ada9e0d2ee9d9823893", size = 1987719, upload-time = "2026-05-18T17:05:02.757Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/34/7db312c5e5783d6e76cffd9d5ac8972a32badae4c6e3288dac0eed8d3bed/black-26.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:89c93167a74d3a75dfaa38a5c7cca015537d5820dd7f17d63267d674a61cae90", size = 1810083, upload-time = "2026-05-18T17:05:04.302Z" },
-    { url = "https://files.pythonhosted.org/packages/33/e2/e0101e73c2c8727634e2efcb35e2b34bd23ad70dfa673789f5773a591b21/black-26.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22f2cd76d069cc54c71f10360744ba8983fbb616903b4304a85b734915c8e1b4", size = 1860633, upload-time = "2026-05-18T17:05:06.391Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/4c/e15c0c5b23cf3651035fe5addcce90e283af3548a3f91bb03d81b83106ab/black-26.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:87ed5c6f450580a2f6790bc7cbfb016dfc73bc750249762268a3695361315eef", size = 1477886, upload-time = "2026-05-18T17:05:07.96Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/3f/59d43ade98d2ce5c8dc34a4e46cbecd177e6d55d7d4092969c6003ccc655/black-26.5.1-cp310-cp310-win_arm64.whl", hash = "sha256:58b4bd92cf88aacf83d88479c8f9caee044b1ec55f2451a337354a7ea2590a22", size = 1277111, upload-time = "2026-05-18T17:05:09.473Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/96/3c3e09f09f44a37aac36b178a279cd19aa7001bd796187a7b162a294c81f/black-26.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96ae2c733b2aabdd9986e2c5df628ff3473676cd1c5faded1ff496cf6d74083c", size = 1970639, upload-time = "2026-05-18T17:05:11.461Z" },
-    { url = "https://files.pythonhosted.org/packages/83/ea/5ad117b9ee3ecd933c712bcbae610006e5b7cc9f41c526cd7ed3b6c4124c/black-26.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0e48b87e03bf109288e55cfceadcfa15ff5470aca2851a851950ed2926f450d7", size = 1792130, upload-time = "2026-05-18T17:05:12.983Z" },
-    { url = "https://files.pythonhosted.org/packages/06/3a/7c448bc623fcdfa96672531beb5a616ea5e64f6975955254d7731ffb0ad9/black-26.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5119fa92ae61f786e8c3662fd60aece1d0a2dd5cca5d0c79417a95e7a4272a59", size = 1846134, upload-time = "2026-05-18T17:05:14.506Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/5b/0b39b3a5917f0657ac014ad2edb58c139553a478adfe7f817abf1622ff6e/black-26.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:30d3c14661f2792e9142cce3eeeb1cbc175b3eb5f733be0c8eeb99651e52b0c3", size = 1478883, upload-time = "2026-05-18T17:05:16.542Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/48/dc222692e0f95030db1bbfb6c857e76858bad09058221ea7aae815255327/black-26.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:1ef92b76f7733f282fd096ea406200b5a286c42947412b0eaff3a74e3616cefe", size = 1277776, upload-time = "2026-05-18T17:05:18.029Z" },
-    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
-    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
-    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
-    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
-    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
-]
-
-[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -819,15 +775,6 @@ wheels = [
 ]
 
 [[package]]
-name = "isort"
-version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/82/fa43935523efdfcce6abbae9da7f372b627b27142c3419fcf13bf5b0c397/isort-6.1.0.tar.gz", hash = "sha256:9b8f96a14cfee0677e78e941ff62f03769a06d412aabb9e2a90487b3b7e8d481", size = 824325, upload-time = "2025-10-01T16:26:45.027Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/cc/9b681a170efab4868a032631dea1e8446d8ec718a7f657b94d49d1a12643/isort-6.1.0-py3-none-any.whl", hash = "sha256:58d8927ecce74e5087aef019f778d4081a3b6c98f15a80ba35782ca8a2097784", size = 94329, upload-time = "2025-10-01T16:26:43.291Z" },
-]
-
-[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1027,15 +974,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "nh3"
 version = "0.3.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1115,24 +1053,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.11.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]
@@ -1267,45 +1187,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytokens"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
-    { url = "https://files.pythonhosted.org/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
-    { url = "https://files.pythonhosted.org/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
-    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
-    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
-    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
-    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
-    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
-    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
-    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
-    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
-]
-
-[[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1357,16 +1238,15 @@ docs = [
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 test = [
-    { name = "black" },
     { name = "codecov" },
     { name = "coverage" },
     { name = "django", version = "5.2.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "freezegun" },
-    { name = "isort" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-django" },
+    { name = "ruff" },
     { name = "sample-pypi-package" },
     { name = "tabulate" },
 ]
@@ -1385,15 +1265,14 @@ provides-extras = ["django", "flask"]
 deploy = [{ name = "twine" }]
 docs = [{ name = "sphinx" }]
 test = [
-    { name = "black", specifier = "==26.5.1" },
     { name = "codecov", specifier = ">=2.0.0" },
     { name = "coverage", specifier = ">=4.4.0" },
     { name = "django" },
     { name = "freezegun", specifier = "==1.5.5" },
-    { name = "isort", specifier = "~=6.1.0" },
     { name = "pytest", specifier = "==8.4.2" },
     { name = "pytest-cov", specifier = ">=2.7.0" },
     { name = "pytest-django", specifier = ">=4.5" },
+    { name = "ruff", specifier = "==0.15.22" },
     { name = "sample-pypi-package", directory = "tests/sample_pypi_package" },
     { name = "tabulate" },
 ]
@@ -1454,6 +1333,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Part of #304. Replaces black + isort with **ruff** as the single linting, import-sorting and formatting tool.

**Commit 1 — tooling swap:**
- `[tool.ruff]` config: rules `E, W, F, I, C4, C90, UP, B, N, RUF`, line-length 88, everything fixable, `E501` ignored under `tests/`.
- `black`/`isort` removed from the test dependency group; `ruff==0.15.22` pinned (same determinism rationale as the old black pin).
- `make lint` → `ruff check` + `ruff format --check`; `make lint-fix` → `ruff check --fix` + `ruff format`.

**Commit 2 — bringing the codebase up to the new rules** (58 findings):
- Autofixes: f-string cleanups, unused imports, PEP 585/604 modernizations (`UP`), stale `# noqa` directives.
- Manual: `stacklevel=2` on deprecation warnings (B028), printf-style → f-strings (UP031), `type(a) == type(b)` → `is` (E721), a pytest fixture with a wrong first argument (N805), unnecessary `map()` (C417).
- Long docstring lines: the old `# noqa` markers lived *inside* docstrings — flake8 honored them, ruff doesn't. Wrapped the lines, moved giant URLs to RST link targets and refreshed them to their current `googleapis.dev` homes. Sphinx docs verified to build without new warnings.
- `UnrecoverableException` keeps its N818-violating name with a targeted `noqa`: renaming it would break the public API. The test-only `CustomException` → `CustomError`.

## Testing

- `make lint` green (ruff check + format).
- Full suite: 102 passed.
- `make html -C docs` builds cleanly (only the pre-existing settings.rst underline warning).

Generated with Claude Code