### PR TITLE
[Fixed] Stop the worker-stop test from racing a real Pub/Sub connection

### DIFF
--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -54,7 +54,14 @@ def worker_without_client_options(config):
 @pytest.fixture
 def mock_consume(config):
     with patch.object(Subscriber, "consume") as m:
-        client = pubsub_v1.SubscriberClient(credentials=config.credentials)
+        # Point the client at a non-routable endpoint so the streaming pull
+        # never reaches Google: a real request answered with a terminal error
+        # (e.g. 401) would be re-raised by future.result() and make any test
+        # that stops the worker fail depending on network timing.
+        client = pubsub_v1.SubscriberClient(
+            credentials=config.credentials,
+            client_options={"api_endpoint": "localhost:1"},
+        )
         m.return_value = client.subscribe("dummy-subscription", Callback(sub_stub))
         yield m
 


### PR DESCRIPTION
## Description

Fixes #311.

`test_stop_cancels_futures_and_closes_subscriber` failed intermittently in CI with `Unauthenticated: 401` — it has already bitten two PRs this week (#310 and #315), needing manual reruns.

Root cause (full analysis in #311): the `mock_consume` fixture patches `Subscriber.consume` but builds its return value by opening a **real streaming pull against Google** with the dummy credentials. The test then races: if Google's terminal 401 lands on the `StreamingPullFuture` before `worker.stop()` calls `future.result()`, the stored exception is re-raised.

The fix points the fixture's client at a non-routable endpoint (`localhost:1`): connection failures are retryable for streaming pulls, so the future stays pending until cancelled — real `cancel()`/`result()`/`_state` semantics preserved, but no request ever leaves the machine and there is no terminal error to race against.

## Testing

- `tests/test_worker.py` run 3× consecutively: 19 passed each time.
- Full suite: 102 passed.

Generated with Claude Code