### PR TITLE
[Added] Type hints for the public API, checked by mypy strict

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Linting
         run: make lint
 
+      - name: Type checking
+        run: make typecheck
+
       - name: Coverage
         run: |
           make coverage

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ lint: ## check for coding style issues
 	uv run ruff check .
 	uv run ruff format --check .
 
+typecheck: ## check type annotations with mypy
+	uv run mypy
+
 lint-fix: ## try to automagically fix coding style issues
 	uv run ruff check --fix .
 	uv run ruff format .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ test = [
     "coverage>=4.4.0",
     "codecov>=2.0.0",
     "ruff==0.15.22",
+    "mypy==2.3.0",
     "freezegun==1.5.5",
     "django",
     "tabulate",
@@ -86,6 +87,37 @@ unfixable = []
 
 [tool.ruff.lint.extend-per-file-ignores]
 "tests/*" = ["E501"]
+
+[tool.mypy]
+# see https://mypy.readthedocs.io/en/stable/config_file.html#the-mypy-configuration-file
+files = ["rele"]
+
+# this makes things more strict and enforces checking non-annotated code
+strict = true
+
+# to keep things clean
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+# Workaround for bug in MyPy
+disallow_subclassing_any = false
+
+# enable these for even more strictness
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+
+# this will enable checks even for non-annotated methods
+check_untyped_defs = true
+warn_return_any = true
+no_implicit_optional = true
+strict_optional = true
+
+# this helps when working with untyped libraries
+ignore_missing_imports = true
+
+# depends on the project
+namespace_packages = false
+explicit_package_bases = false
 
 [tool.coverage.run]
 include = ["*"]

--- a/rele/__main__.py
+++ b/rele/__main__.py
@@ -10,7 +10,7 @@ from rele.worker import create_and_run
 logger = logging.getLogger(__name__)
 
 
-def main():
+def main() -> None:
     # modify path so we can import modules and packages
     sys.path.insert(0, os.getcwd())
 
@@ -49,22 +49,22 @@ def main():
         run_worker(args.settings, args.third_party_subscriptions)
 
 
-def run_worker(settings, third_party_subs):
-    settings, module_paths = discover.sub_modules(settings)
+def run_worker(settings: str | None, third_party_subs: list[str] | None) -> None:
+    settings_module, module_paths = discover.sub_modules(settings)
 
     if third_party_subs:
         validated_third_party_subs = _validated_third_party_subs(third_party_subs)
         module_paths = module_paths + validated_third_party_subs
 
-    configuration = config.setup(settings.RELE if settings else None)
+    configuration = config.setup(settings_module.RELE if settings_module else None)
     subs = config.load_subscriptions_from_paths(
         module_paths, configuration.sub_prefix, configuration.filter_by
     )
     create_and_run(subs, configuration)
 
 
-def _validated_third_party_subs(subs_import_path):
-    validated_subs = []
+def _validated_third_party_subs(subs_import_path: list[str]) -> list[str]:
+    validated_subs: list[str] = []
     for sub_path in subs_import_path:
         if _is_valid_module(sub_path):
             validated_subs.append(sub_path)
@@ -72,7 +72,7 @@ def _validated_third_party_subs(subs_import_path):
     return validated_subs
 
 
-def _is_valid_module(import_path):
+def _is_valid_module(import_path: str) -> bool:
     is_valid = False
     try:
         importlib.import_module(import_path)

--- a/rele/apps.py
+++ b/rele/apps.py
@@ -7,5 +7,5 @@ import rele.config
 class ReleConfig(AppConfig):
     name = "rele"
 
-    def ready(self):
+    def ready(self) -> None:
         rele.config.setup(settings.RELE)

--- a/rele/client.py
+++ b/rele/client.py
@@ -3,7 +3,9 @@ import logging
 import os
 import time
 import warnings
+from collections.abc import Callable
 from concurrent.futures import TimeoutError
+from typing import Any
 
 import google.auth
 from google.api_core import exceptions
@@ -14,6 +16,8 @@ from google.pubsub_v1 import MessageStoragePolicy
 from google.pubsub_v1 import RetryPolicy as GCloudRetryPolicy
 
 from rele.middleware import run_middleware_hook
+from rele.retry_policy import RetryPolicy
+from rele.subscription import Subscription
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +27,7 @@ DEFAULT_ACK_DEADLINE = 60
 DEFAULT_BLOCKING = False
 
 
-def get_google_defaults():
+def get_google_defaults() -> tuple[Any, Any]:
     try:
         credentials, project = google.auth.default()
         return credentials, project
@@ -46,13 +50,13 @@ class Subscriber:
 
     def __init__(
         self,
-        gc_project_id,
-        credentials,
-        message_storage_policy,
-        client_options,
-        default_ack_deadline=None,
-        default_retry_policy=None,
-    ):
+        gc_project_id: str | None,
+        credentials: Any,
+        message_storage_policy: str | list[str] | None,
+        client_options: dict[str, Any] | None,
+        default_ack_deadline: int | None = None,
+        default_retry_policy: RetryPolicy | None = None,
+    ) -> None:
         self._gc_project_id = gc_project_id
         self._ack_deadline = default_ack_deadline or DEFAULT_ACK_DEADLINE
         self.credentials = credentials if not USE_EMULATOR else None
@@ -64,7 +68,7 @@ class Subscriber:
         )
         self._retry_policy = default_retry_policy
 
-    def update_or_create_subscription(self, subscription):
+    def update_or_create_subscription(self, subscription: Subscription) -> None:
         """Handles creating the subscription when it does not exists or updates it
         if the subscription contains any parameter that allows it.
 
@@ -92,7 +96,7 @@ class Subscriber:
         except exceptions.AlreadyExists:
             self._update_subscription(subscription_path, topic_path, subscription)
 
-    def _create_topic(self, topic_path):
+    def _create_topic(self, topic_path: str) -> Any:
         publisher_client = pubsub_v1.PublisherClient(credentials=self.credentials)
         return publisher_client.create_topic(
             request={
@@ -103,7 +107,9 @@ class Subscriber:
             }
         )
 
-    def _normalize_storage_policy(self, policy):
+    def _normalize_storage_policy(
+        self, policy: str | list[str] | None
+    ) -> list[str] | None:
         """
         Normalizes the storage policy to accept either a string or a list.
         If it is a string, it converts it into a list with a single element.
@@ -129,8 +135,10 @@ class Subscriber:
             "or a list of regions."
         )
 
-    def _create_subscription(self, subscription_path, topic_path, subscription):
-        request = {
+    def _create_subscription(
+        self, subscription_path: str, topic_path: str, subscription: Subscription
+    ) -> None:
+        request: dict[str, Any] = {
             "name": subscription_path,
             "topic": topic_path,
             "ack_deadline_seconds": self._ack_deadline,
@@ -146,7 +154,9 @@ class Subscriber:
 
         self._client.create_subscription(request=request)
 
-    def _update_subscription(self, subscription_path, topic_path, subscription):
+    def _update_subscription(
+        self, subscription_path: str, topic_path: str, subscription: Subscription
+    ) -> None:
         retry_policy = subscription.retry_policy or self._retry_policy
 
         if not retry_policy:
@@ -156,17 +166,19 @@ class Subscriber:
 
         client_retry_policy = self._build_gcloud_retry_policy(retry_policy)
 
-        subscription = pubsub_v1.types.Subscription(
+        gcloud_subscription = pubsub_v1.types.Subscription(
             name=subscription_path,
             topic=topic_path,
             retry_policy=client_retry_policy,
         )
 
         self._client.update_subscription(
-            request={"subscription": subscription, "update_mask": update_mask}
+            request={"subscription": gcloud_subscription, "update_mask": update_mask}
         )
 
-    def _build_gcloud_retry_policy(self, rele_retry_policy):
+    def _build_gcloud_retry_policy(
+        self, rele_retry_policy: RetryPolicy
+    ) -> GCloudRetryPolicy:
         minimum_backoff = duration_pb2.Duration(
             seconds=rele_retry_policy.minimum_backoff
         )
@@ -178,7 +190,9 @@ class Subscriber:
             minimum_backoff=minimum_backoff, maximum_backoff=maximum_backoff
         )
 
-    def consume(self, subscription_name, callback, scheduler):
+    def consume(
+        self, subscription_name: str, callback: Callable[[Any], Any], scheduler: Any
+    ) -> Any:
         """Begin listening to topic from the SubscriberClient.
 
         :param subscription_name: str Subscription name
@@ -198,7 +212,7 @@ class Subscriber:
             subscription_path, callback=callback, scheduler=scheduler
         )
 
-    def close(self):
+    def close(self) -> None:
         """Close the SubscriberClient."""
         self._client.close()
 
@@ -226,13 +240,13 @@ class Publisher:
 
     def __init__(
         self,
-        gc_project_id,
-        credentials,
-        encoder,
-        timeout,
-        client_options,
-        blocking=None,
-    ):
+        gc_project_id: str | None,
+        credentials: Any,
+        encoder: type[json.JSONEncoder],
+        timeout: float,
+        client_options: dict[str, Any] | None,
+        blocking: bool | None = None,
+    ) -> None:
         self._gc_project_id = gc_project_id
         self._timeout = timeout
         self._blocking = blocking
@@ -245,8 +259,14 @@ class Publisher:
             )
 
     def publish(
-        self, topic, data, blocking=None, timeout=None, raise_exception=True, **attrs
-    ):
+        self,
+        topic: str,
+        data: Any,
+        blocking: bool | None = None,
+        timeout: float | None = None,
+        raise_exception: bool = True,
+        **attrs: Any,
+    ) -> Any:
         """Publishes message to Google PubSub topic.
 
         Usage::

--- a/rele/config.py
+++ b/rele/config.py
@@ -1,5 +1,8 @@
 import importlib
+import json
 import os
+from collections.abc import Callable, Iterable
+from typing import Any, cast
 
 from google.oauth2 import service_account
 
@@ -11,6 +14,7 @@ from .client import (
 )
 from .middleware import default_middleware, register_middleware
 from .publishing import init_global_publisher
+from .retry_policy import RetryPolicy
 from .subscription import Subscription
 
 
@@ -25,39 +29,43 @@ class Config:
     :param setting: dict :ref:`settings <_settings>`
     """
 
-    def __init__(self, setting):
-        self._gc_project_id = setting.get("GC_PROJECT_ID")
-        self.gc_credentials_path = setting.get("GC_CREDENTIALS_PATH")
-        self.gc_storage_region = setting.get(
+    def __init__(self, setting: dict[str, Any]) -> None:
+        self._gc_project_id: str | None = setting.get("GC_PROJECT_ID")
+        self.gc_credentials_path: str | None = setting.get("GC_CREDENTIALS_PATH")
+        self.gc_storage_region: str | list[str] | None = setting.get(
             "GC_STORAGE_REGION",
             ["europe-southwest1", "europe-west1", "europe-west8", "europe-west9"],
         )
-        self.app_name = setting.get("APP_NAME")
-        self.sub_prefix = setting.get("SUB_PREFIX")
-        self.middleware = setting.get("MIDDLEWARE", default_middleware)
-        self.ack_deadline = setting.get(
+        self.app_name: str | None = setting.get("APP_NAME")
+        self.sub_prefix: str | None = setting.get("SUB_PREFIX")
+        self.middleware: list[str] = setting.get("MIDDLEWARE", default_middleware)
+        self.ack_deadline: int = setting.get(
             "ACK_DEADLINE",
             os.environ.get("DEFAULT_ACK_DEADLINE", DEFAULT_ACK_DEADLINE),
         )
-        self.publisher_blocking = setting.get("PUBLISHER_BLOCKING", DEFAULT_BLOCKING)
-        self._encoder_path = setting.get("ENCODER_PATH", DEFAULT_ENCODER_PATH)
-        self.publisher_timeout = setting.get("PUBLISHER_TIMEOUT", 3.0)
-        self.threads_per_subscription = setting.get("THREADS_PER_SUBSCRIPTION", 2)
-        self.filter_by = setting.get("FILTER_SUBS_BY")
-        self._credentials = None
-        self.retry_policy = setting.get("DEFAULT_RETRY_POLICY")
-        self.client_options = setting.get("CLIENT_OPTIONS")
+        self.publisher_blocking: bool = setting.get(
+            "PUBLISHER_BLOCKING", DEFAULT_BLOCKING
+        )
+        self._encoder_path: str = setting.get("ENCODER_PATH", DEFAULT_ENCODER_PATH)
+        self.publisher_timeout: float = setting.get("PUBLISHER_TIMEOUT", 3.0)
+        self.threads_per_subscription: int = setting.get("THREADS_PER_SUBSCRIPTION", 2)
+        self.filter_by: Callable[..., bool] | Iterable[Callable[..., bool]] | None = (
+            setting.get("FILTER_SUBS_BY")
+        )
+        self._credentials: Any = None
+        self.retry_policy: RetryPolicy | None = setting.get("DEFAULT_RETRY_POLICY")
+        self.client_options: dict[str, Any] | None = setting.get("CLIENT_OPTIONS")
 
     @property
-    def encoder(self):
+    def encoder(self) -> type[json.JSONEncoder]:
         module_name, class_name = self._encoder_path.rsplit(".", 1)
         module = importlib.import_module(module_name)
-        return getattr(module, class_name)
+        return cast(type[json.JSONEncoder], getattr(module, class_name))
 
     @property
-    def credentials(self):
+    def credentials(self) -> Any:
         if self.gc_credentials_path:
-            self._credentials = service_account.Credentials.from_service_account_file(
+            self._credentials = service_account.Credentials.from_service_account_file(  # type: ignore[no-untyped-call]
                 self.gc_credentials_path
             )
         else:
@@ -68,16 +76,16 @@ class Config:
         return self._credentials
 
     @property
-    def gc_project_id(self):
+    def gc_project_id(self) -> str | None:
         if self._gc_project_id:
             return self._gc_project_id
         elif self.credentials:
-            return self.credentials.project_id
+            return cast(str, self.credentials.project_id)
         else:
             return None
 
 
-def setup(setting=None, **kwargs):
+def setup(setting: dict[str, Any] | None = None, **kwargs: Any) -> Config:
     if setting is None:
         setting = {}
 
@@ -87,16 +95,20 @@ def setup(setting=None, **kwargs):
     return config
 
 
-def is_same_subscription(a_subscription, another_subscription):
+def is_same_subscription(
+    a_subscription: Subscription | None, another_subscription: Subscription
+) -> bool:
     return id(a_subscription) == id(another_subscription)
 
 
-def is_subscription_registered(subscriptions, current_subscription):
+def is_subscription_registered(
+    subscriptions: dict[str, Subscription], current_subscription: Subscription
+) -> bool:
     registered_subscription = subscriptions.get(current_subscription.name)
     return is_same_subscription(registered_subscription, current_subscription)
 
 
-def subscription_from_attribute(attribute):
+def subscription_from_attribute(attribute: Any) -> Subscription | None:
     try:
         if isinstance(attribute, Subscription):
             subscription = attribute
@@ -110,8 +122,12 @@ def subscription_from_attribute(attribute):
     return subscription
 
 
-def load_subscriptions_from_paths(sub_module_paths, sub_prefix=None, filter_by=None):
-    subscriptions = {}
+def load_subscriptions_from_paths(
+    sub_module_paths: list[str],
+    sub_prefix: str | None = None,
+    filter_by: Callable[..., bool] | Iterable[Callable[..., bool]] | None = None,
+) -> list[Subscription]:
+    subscriptions: dict[str, Subscription] = {}
     for sub_module_path in sub_module_paths:
         sub_module = importlib.import_module(sub_module_path)
         for attr_name in dir(sub_module):

--- a/rele/contrib/django_db_middleware.py
+++ b/rele/contrib/django_db_middleware.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django import db
 
 from rele.middleware import BaseMiddleware
@@ -6,11 +8,11 @@ from rele.middleware import BaseMiddleware
 class DjangoDBMiddleware(BaseMiddleware):
     """Django specific middleware for managing database connections."""
 
-    def pre_process_message(self, *args):
+    def pre_process_message(self, *args: Any) -> None:
         db.close_old_connections()
 
-    def post_process_message(self):
+    def post_process_message(self) -> None:
         db.close_old_connections()
 
-    def post_worker_stop(self):
+    def post_worker_stop(self) -> None:
         db.connections.close_all()

--- a/rele/contrib/flask_middleware.py
+++ b/rele/contrib/flask_middleware.py
@@ -1,13 +1,19 @@
+from typing import TYPE_CHECKING, Any
+
 from rele.middleware import BaseMiddleware
+
+if TYPE_CHECKING:
+    from rele.config import Config
+    from rele.subscription import Subscription
 
 
 class FlaskMiddleware(BaseMiddleware):
-    def setup(self, config, **kwargs):
+    def setup(self, config: "Config", **kwargs: Any) -> None:
         self.app = kwargs["flask_app"]
 
-    def pre_process_message(self, subscription, message):
+    def pre_process_message(self, subscription: "Subscription", message: Any) -> None:
         self.ctx = self.app.app_context()
         self.ctx.push()
 
-    def post_process_message(self):
+    def post_process_message(self) -> None:
         self.ctx.pop()

--- a/rele/contrib/logging_middleware.py
+++ b/rele/contrib/logging_middleware.py
@@ -1,8 +1,13 @@
 import json
 import logging
 import time
+from typing import TYPE_CHECKING, Any
 
 from rele.middleware import BaseMiddleware
+
+if TYPE_CHECKING:
+    from rele.config import Config
+    from rele.subscription import Subscription
 
 
 class LoggingMiddleware(BaseMiddleware):
@@ -11,18 +16,22 @@ class LoggingMiddleware(BaseMiddleware):
     Logging format has been configured for Prometheus.
     """
 
-    def __init__(self):
-        self._logger = None
-
-    def setup(self, config, **kwargs):
+    def __init__(self) -> None:
         self._logger = logging.getLogger(__name__)
-        self._app_name = config.app_name
-        self._encoder = config.encoder
+
+    def setup(self, config: "Config", **kwargs: Any) -> None:
+        self._logger = logging.getLogger(__name__)
+        self._app_name: str | None = config.app_name
+        self._encoder: type[json.JSONEncoder] = config.encoder
 
     def _build_data_metrics(
-        self, subscription, message, status, start_processing_time=None
-    ):
-        result = {
+        self,
+        subscription: "Subscription",
+        message: Any,
+        status: str,
+        start_processing_time: float | None = None,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
             "agent": self._app_name,
             "topic": subscription.topic,
             "status": status,
@@ -38,7 +47,7 @@ class LoggingMiddleware(BaseMiddleware):
 
         return result
 
-    def pre_publish(self, topic, data, attrs):
+    def pre_publish(self, topic: str, data: Any, attrs: dict[str, Any]) -> None:
         self._logger.debug(
             f"Publishing to {topic}",
             extra={
@@ -50,7 +59,9 @@ class LoggingMiddleware(BaseMiddleware):
             },
         )
 
-    def post_publish_success(self, topic, data, attrs):
+    def post_publish_success(
+        self, topic: str, data: Any, attrs: dict[str, Any]
+    ) -> None:
         self._logger.info(
             f"Successfully published to {topic}",
             extra={
@@ -62,7 +73,9 @@ class LoggingMiddleware(BaseMiddleware):
             },
         )
 
-    def post_publish_failure(self, topic, exception, message):
+    def post_publish_failure(
+        self, topic: str, exception: Exception, message: Any
+    ) -> None:
         self._logger.exception(
             f"Exception raised while publishing message "
             f"for {topic}: {exception.__class__.__name__!s}",
@@ -76,7 +89,7 @@ class LoggingMiddleware(BaseMiddleware):
             },
         )
 
-    def pre_process_message(self, subscription, message):
+    def pre_process_message(self, subscription: "Subscription", message: Any) -> None:
         self._logger.debug(
             f"Start processing message for {subscription}",
             extra={
@@ -87,7 +100,9 @@ class LoggingMiddleware(BaseMiddleware):
             },
         )
 
-    def post_process_message_success(self, subscription, start_time, message):
+    def post_process_message_success(
+        self, subscription: "Subscription", start_time: float, message: Any
+    ) -> None:
         self._logger.info(
             f"Successfully processed message for {subscription}",
             extra={
@@ -101,8 +116,12 @@ class LoggingMiddleware(BaseMiddleware):
         )
 
     def post_process_message_failure(
-        self, subscription, exception, start_time, message
-    ):
+        self,
+        subscription: "Subscription",
+        exception: Exception,
+        start_time: float,
+        message: Any,
+    ) -> None:
         self._logger.error(
             f"Exception raised while processing message "
             f"for {subscription}: {exception.__class__.__name__!s}",
@@ -118,5 +137,5 @@ class LoggingMiddleware(BaseMiddleware):
             },
         )
 
-    def pre_worker_stop(self, subscriptions):
+    def pre_worker_stop(self, subscriptions: list["Subscription"]) -> None:
         self._logger.info(f"Cleaning up {len(subscriptions)} subscription(s)...")

--- a/rele/contrib/unrecoverable_middleware.py
+++ b/rele/contrib/unrecoverable_middleware.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING, Any
+
 from rele.middleware import BaseMiddleware
+
+if TYPE_CHECKING:
+    from rele.subscription import Subscription
 
 
 class UnrecoverableException(Exception):  # noqa: N818 -- renaming would break the public API
@@ -6,6 +11,12 @@ class UnrecoverableException(Exception):  # noqa: N818 -- renaming would break t
 
 
 class UnrecoverableMiddleWare(BaseMiddleware):
-    def post_process_message_failure(self, subscription, err, start_time, message):
+    def post_process_message_failure(
+        self,
+        subscription: "Subscription",
+        err: Exception,
+        start_time: float,
+        message: Any,
+    ) -> None:
         if isinstance(err, UnrecoverableException):
             message.ack()

--- a/rele/contrib/verbose_logging_middleware.py
+++ b/rele/contrib/verbose_logging_middleware.py
@@ -1,14 +1,21 @@
 import json
+from typing import TYPE_CHECKING, Any
 
 from rele.contrib.logging_middleware import LoggingMiddleware
 
+if TYPE_CHECKING:
+    from rele.config import Config
+    from rele.subscription import Subscription
+
 
 class VerboseLoggingMiddleware(LoggingMiddleware):
-    def setup(self, config, **kwargs):
+    def setup(self, config: "Config", **kwargs: Any) -> None:
         super().setup(config, **kwargs)
         self._encoder = config.encoder
 
-    def post_publish_success(self, topic, message_data, message_attributes):
+    def post_publish_success(
+        self, topic: str, message_data: Any, message_attributes: dict[str, Any]
+    ) -> None:
         self._logger.info(
             f"Successfully published to {topic}",
             extra={
@@ -21,7 +28,9 @@ class VerboseLoggingMiddleware(LoggingMiddleware):
             },
         )
 
-    def post_process_message_success(self, subscription, start_time, message):
+    def post_process_message_success(
+        self, subscription: "Subscription", start_time: float, message: Any
+    ) -> None:
         self._logger.info(
             f"Successfully processed message for {subscription}",
             extra={
@@ -36,19 +45,23 @@ class VerboseLoggingMiddleware(LoggingMiddleware):
         )
 
     def post_process_message_failure(
-        self, subscription, exception, start_time, message
-    ):
+        self,
+        subscription: "Subscription",
+        exception: Exception,
+        start_time: float,
+        message: Any,
+    ) -> None:
         super().post_process_message_failure(
             subscription, exception, start_time, _VerboseMessage(message)
         )
 
 
 class _VerboseMessage:
-    def __init__(self, message):
+    def __init__(self, message: Any) -> None:
         self._message = message
         self.attributes = message.attributes
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         message_repr = """\
 Message {{
   data: {!r}
@@ -62,7 +75,7 @@ Message {{
 
         return message_repr.format(data, ordering_key, attrs)
 
-    def _message_attrs_repr(self):
+    def _message_attrs_repr(self) -> str:
         message_attrs = json.dumps(
             dict(self.attributes), indent=2, separators=(",", ": "), sort_keys=True
         )

--- a/rele/discover.py
+++ b/rele/discover.py
@@ -2,11 +2,12 @@ import importlib
 import logging
 import pkgutil
 from importlib.util import find_spec as importlib_find
+from types import ModuleType
 
 logger = logging.getLogger(__name__)
 
 
-def module_has_submodule(package, module_name):
+def module_has_submodule(package: str, module_name: str) -> bool:
     """
     See if 'module' is in 'package'.
     Taken from https://github.com/django/django/blob/master/django/utils/module_loading.py#L63
@@ -16,20 +17,25 @@ def module_has_submodule(package, module_name):
     package_path = imported_package.__path__
     full_module_name = package_name + "." + module_name
     try:
-        return importlib_find(full_module_name, package_path) is not None
+        # find_spec ignores its second argument for absolute module names, so
+        # passing __path__ (a list) instead of the str the stubs expect is fine
+        return importlib_find(full_module_name, package_path) is not None  # type: ignore[arg-type]
     except (ModuleNotFoundError, AttributeError):
         # When module_name is an invalid dotted path, Python raises
         # ModuleNotFoundError.
         return False
 
 
-def _import_settings_from_path(path):
+def _import_settings_from_path(path: str | None) -> ModuleType | None:
     if path is not None:
         print(f" * Discovered settings: {path!r}")
         return importlib.import_module(path)
+    return None
 
 
-def sub_modules(settings_path=None):
+def sub_modules(
+    settings_path: str | None = None,
+) -> tuple[ModuleType | None, list[str]]:
     """
     In the current directory, we can traverse all modules and determine if they
     have a settings.py or directory with a subs.py module. If either one of
@@ -40,7 +46,7 @@ def sub_modules(settings_path=None):
 
     :return: (settings module, List[string: subs module paths])
     """
-    module_paths = []
+    module_paths: list[str] = []
     for _, package, is_package in pkgutil.walk_packages(path=["."]):
         if package == "settings":
             settings_path = package

--- a/rele/management/commands/runrele.py
+++ b/rele/management/commands/runrele.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from django.conf import settings
 from django.core.management import BaseCommand
@@ -14,7 +15,7 @@ class Command(BaseCommand):
     help = "Start subscriber threads to consume messages from Relé topics."
     config = config.Config(settings.RELE)
 
-    def handle(self, *args, **options):
+    def handle(self, *args: Any, **options: Any) -> None:
         if all(x.get("CONN_MAX_AGE") for x in settings.DATABASES.values()):
             self.stderr.write(
                 self.style.WARNING(

--- a/rele/management/commands/showsubscriptions.py
+++ b/rele/management/commands/showsubscriptions.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.core.management import BaseCommand
 from tabulate import tabulate
 
@@ -8,7 +10,7 @@ from rele.management.discover import discover_subs_modules
 class Command(BaseCommand):
     help = "List information about Pub/Sub subscriptions registered using Relé."
 
-    def handle(self, *args, **options):
+    def handle(self, *args: Any, **options: Any) -> None:
         headers = ["Topic", "Subscriber(s)", "Sub"]
 
         subscription_paths = discover_subs_modules()

--- a/rele/management/discover.py
+++ b/rele/management/discover.py
@@ -1,17 +1,20 @@
 import logging
 import os
 import re
+from typing import Any
 
 from django.apps import apps
 
 logger = logging.getLogger(__name__)
 
 
-def is_subs_module(file):
+def is_subs_module(file: str) -> re.Match[str] | None:
     return re.match(r"^(subs|subs\.py)$", file)
 
 
-def collect_subs_from_path(folder_path, subfiles, module_name, subs_paths):
+def collect_subs_from_path(
+    folder_path: str, subfiles: list[str], module_name: str, subs_paths: list[str]
+) -> list[str]:
     if not subfiles:
         return subs_paths
 
@@ -37,7 +40,7 @@ def collect_subs_from_path(folder_path, subfiles, module_name, subs_paths):
     return collect_subs_from_path(folder_path, subfiles, module_name, subs_paths)
 
 
-def collect_subs_from_app(app_config):
+def collect_subs_from_app(app_config: Any) -> list[str]:
     return collect_subs_from_path(
         folder_path=app_config.path,
         subfiles=os.listdir(app_config.path),
@@ -46,10 +49,10 @@ def collect_subs_from_app(app_config):
     )
 
 
-def discover_subs_modules():
+def discover_subs_modules() -> list[str]:
     logger.debug("Autodiscovering subs...")
     app_configs = apps.get_app_configs()
-    subs_modules = []
+    subs_modules: list[str] = []
 
     for app in app_configs:
         subs_modules += collect_subs_from_app(app)

--- a/rele/middleware.py
+++ b/rele/middleware.py
@@ -1,13 +1,18 @@
 import importlib
 import warnings
+from typing import TYPE_CHECKING, Any
 
-_middlewares = []
+if TYPE_CHECKING:
+    from rele.config import Config
+    from rele.subscription import Subscription
+
+_middlewares: list["BaseMiddleware"] = []
 
 default_middleware = ["rele.contrib.LoggingMiddleware"]
 DEPRECATED_HOOKS = ["post_publish"]
 
 
-def register_middleware(config, **kwargs):
+def register_middleware(config: "Config", **kwargs: Any) -> None:
     paths = config.middleware
     global _middlewares
     _middlewares = []
@@ -20,15 +25,15 @@ def register_middleware(config, **kwargs):
         _middlewares.append(middleware)
 
 
-def run_middleware_hook(hook_name, *args, **kwargs):
+def run_middleware_hook(hook_name: str, *args: Any, **kwargs: Any) -> None:
     for middleware in _middlewares:
         if hook_name not in DEPRECATED_HOOKS or hasattr(middleware, hook_name):
             getattr(middleware, hook_name)(*args, **kwargs)
 
 
 class WarnDeprecatedHooks(type):
-    def __new__(cls, *args, **kwargs):
-        x = super().__new__(cls, *args, **kwargs)
+    def __new__(cls, *args: Any, **kwargs: Any) -> type:
+        x: type = super().__new__(cls, *args, **kwargs)
         for deprecated_hook in DEPRECATED_HOOKS:
             if hasattr(x, deprecated_hook):
                 warnings.warn(
@@ -47,42 +52,48 @@ class BaseMiddleware(metaclass=WarnDeprecatedHooks):
     subset of hooks they like.
     """
 
-    def setup(self, config, **kwargs):
+    def setup(self, config: "Config", **kwargs: Any) -> None:
         """Called when middleware is registered.
         :param config: Relé Config object
         """
 
-    def pre_publish(self, topic, data, attrs):
+    def pre_publish(self, topic: str, data: Any, attrs: dict[str, Any]) -> None:
         """Called before Publisher sends message.
         :param topic:
         :param data:
         :param attrs:
         """
 
-    def post_publish_success(self, topic, data, attrs):
+    def post_publish_success(
+        self, topic: str, data: Any, attrs: dict[str, Any]
+    ) -> None:
         """Called after Publisher succesfully sends message.
         :param topic:
         :param data:
         :param attrs:
         """
 
-    def post_publish_failure(self, topic, exception, message):
+    def post_publish_failure(
+        self, topic: str, exception: Exception, message: Any
+    ) -> None:
         """Called after publishing fails.
         :param topic:
         :param exception:
         :param message:
         """
 
-    def pre_process_message(self, subscription, message):
+    def pre_process_message(self, subscription: "Subscription", message: Any) -> None:
         """Called when the Worker receives a message.
         :param subscription:
         :param message:
         """
 
-    def post_process_message(self):
+    def post_process_message(self) -> None:
         """Called after the Worker processes the message."""
 
-    def post_process_message_success(self, subscription, start_time, message):
+    def post_process_message_success(
+        self, subscription: "Subscription", start_time: float, message: Any
+    ) -> None:
         """Called after the message has been successfully processed.
         :param subscription:
         :param start_time:
@@ -90,8 +101,12 @@ class BaseMiddleware(metaclass=WarnDeprecatedHooks):
         """
 
     def post_process_message_failure(
-        self, subscription, exception, start_time, message
-    ):
+        self,
+        subscription: "Subscription",
+        exception: Exception,
+        start_time: float,
+        message: Any,
+    ) -> None:
         """Called after the message has been unsuccessfully processed.
         :param subscription:
         :param exception:
@@ -99,14 +114,14 @@ class BaseMiddleware(metaclass=WarnDeprecatedHooks):
         :param message:
         """
 
-    def pre_worker_start(self):
+    def pre_worker_start(self) -> None:
         """Called before the Worker process starts up."""
 
-    def post_worker_start(self):
+    def post_worker_start(self) -> None:
         """Called after the Worker process starts up."""
 
-    def pre_worker_stop(self, subscriptions):
+    def pre_worker_stop(self, subscriptions: list["Subscription"]) -> None:
         """Called before the Worker process shuts down."""
 
-    def post_worker_stop(self):
+    def post_worker_stop(self) -> None:
         """Called after the Worker process shuts down."""

--- a/rele/publishing.py
+++ b/rele/publishing.py
@@ -1,11 +1,16 @@
+from typing import TYPE_CHECKING, Any
+
 from rele import config, discover
 
 from .client import Publisher
 
-_publisher = None
+if TYPE_CHECKING:
+    from rele.config import Config
+
+_publisher: Publisher | None = None
 
 
-def init_global_publisher(config):
+def init_global_publisher(config: "Config") -> Publisher:
     global _publisher
     if not _publisher:
         _publisher = Publisher(
@@ -19,7 +24,7 @@ def init_global_publisher(config):
     return _publisher
 
 
-def publish(topic, data, **kwargs):
+def publish(topic: str, data: Any, **kwargs: Any) -> None:
     """Shortcut method to publishing data to PubSub.
 
     This is a shortcut method that instantiates the Publisher if not already
@@ -46,9 +51,10 @@ def publish(topic, data, **kwargs):
     """
     if not _publisher:
         settings, _ = discover.sub_modules()
-        if not hasattr(settings, "RELE"):
+        if settings is None or not hasattr(settings, "RELE"):
             raise ValueError("Config setup not called and settings module not found.")
 
         config.setup(settings.RELE)
 
+    assert _publisher is not None
     _publisher.publish(topic, data, **kwargs)

--- a/rele/retry_policy.py
+++ b/rele/retry_policy.py
@@ -15,13 +15,15 @@ class RetryPolicy:
     minimum_backoff: int
     maximum_backoff: int
 
-    def __init__(self, minimum_backoff, maximum_backoff):
+    def __init__(self, minimum_backoff: int, maximum_backoff: int) -> None:
         self._guard_against_wrong_parameters(minimum_backoff, maximum_backoff)
 
         self.minimum_backoff = minimum_backoff
         self.maximum_backoff = maximum_backoff
 
-    def _guard_against_wrong_parameters(self, minimum_backoff, maximum_backoff):
+    def _guard_against_wrong_parameters(
+        self, minimum_backoff: int, maximum_backoff: int
+    ) -> None:
         if minimum_backoff == 0:
             raise ValueError("minimum_backoff must be greater than 0")
 

--- a/rele/subscription.py
+++ b/rele/subscription.py
@@ -1,10 +1,14 @@
 import json
 import logging
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from inspect import getfullargspec, getmodule
+from typing import Any
 
 from .middleware import run_middleware_hook
+from .retry_policy import RetryPolicy
+
+FilterBy = Callable[..., bool]
 
 logger = logging.getLogger(__name__)
 
@@ -36,14 +40,14 @@ class Subscription:
 
     def __init__(
         self,
-        func,
-        topic,
-        prefix="",
-        suffix="",
-        filter_by=None,
-        backend_filter_by=None,
-        retry_policy=None,
-    ):
+        func: Callable[..., Any],
+        topic: str,
+        prefix: str | None = "",
+        suffix: str | None = "",
+        filter_by: FilterBy | Iterable[FilterBy] | None = None,
+        backend_filter_by: str | None = None,
+        retry_policy: RetryPolicy | None = None,
+    ) -> None:
         self._validate_filter_by(filter_by)
 
         self._func = func
@@ -54,7 +58,9 @@ class Subscription:
         self.backend_filter_by = backend_filter_by
         self.retry_policy = retry_policy
 
-    def _validate_filter_by(self, filter_by):
+    def _validate_filter_by(
+        self, filter_by: FilterBy | Iterable[FilterBy] | None
+    ) -> None:
         if filter_by and not (
             callable(filter_by)
             or (
@@ -64,7 +70,9 @@ class Subscription:
         ):
             raise ValueError("Filter_by must be a callable or a list of callables.")
 
-    def _init_filters(self, filter_by):
+    def _init_filters(
+        self, filter_by: FilterBy | Iterable[FilterBy] | None
+    ) -> Iterable[FilterBy] | None:
         if isinstance(filter_by, Iterable):
             return filter_by
         elif filter_by:
@@ -73,25 +81,25 @@ class Subscription:
         return None
 
     @property
-    def name(self):
+    def name(self) -> str:
         name_parts = [self._prefix, self.topic, self._suffix]
-        return "-".join(filter(lambda x: x, name_parts))
+        return "-".join(filter(None, name_parts))
 
     @property
-    def prefix(self):
+    def prefix(self) -> str | None:
         return self._prefix
 
-    def set_prefix(self, prefix):
+    def set_prefix(self, prefix: str) -> None:
         self._prefix = prefix
 
     @property
-    def filter_by(self):
+    def filter_by(self) -> Iterable[FilterBy] | None:
         return self._filters
 
-    def set_filters(self, filter_by):
-        self._filters = filter_by
+    def set_filters(self, filter_by: FilterBy | Iterable[FilterBy]) -> None:
+        self._filters = self._init_filters(filter_by)
 
-    def __call__(self, data, **kwargs):
+    def __call__(self, data: Any, **kwargs: Any) -> Any:
         if "published_at" in kwargs:
             kwargs["published_at"] = float(kwargs["published_at"])
 
@@ -100,10 +108,10 @@ class Subscription:
 
         return self._func(data, **kwargs)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.name} - {self._func.__name__}"
 
-    def _any_filter_returns_false(self, kwargs):
+    def _any_filter_returns_false(self, kwargs: dict[str, Any]) -> bool:
         if not self._filters:
             return False
 
@@ -111,11 +119,11 @@ class Subscription:
 
 
 class Callback:
-    def __init__(self, subscription, suffix=None):
+    def __init__(self, subscription: Subscription, suffix: str | None = None) -> None:
         self._subscription = subscription
         self._suffix = suffix
 
-    def __call__(self, message):
+    def __call__(self, message: Any) -> Any:
         run_middleware_hook("pre_process_message", self._subscription, message)
         start_time = time.time()
 
@@ -157,13 +165,13 @@ class Callback:
 
 
 def sub(
-    topic,
-    prefix=None,
-    suffix=None,
-    filter_by=None,
-    backend_filter_by=None,
-    retry_policy=None,
-):
+    topic: str,
+    prefix: str | None = None,
+    suffix: str | None = None,
+    filter_by: FilterBy | Iterable[FilterBy] | None = None,
+    backend_filter_by: str | None = None,
+    retry_policy: RetryPolicy | None = None,
+) -> Callable[[Callable[..., Any]], Subscription]:
     """Decorator function that makes declaring a PubSub Subscription simple.
 
     The Subscriber returned will automatically create and name
@@ -212,7 +220,7 @@ def sub(
     :return: :class:`~rele.subscription.Subscription`
     """
 
-    def decorator(func):
+    def decorator(func: Callable[..., Any]) -> Subscription:
         args_spec = getfullargspec(func)
         if len(args_spec.args) != 1 or not args_spec.varkw:
             raise RuntimeError(
@@ -221,7 +229,9 @@ def sub(
                 "accept keyword arguments."
             )
 
-        if getmodule(func).__name__.split(".")[-1] != "subs":
+        module = getmodule(func)
+        module_name = module.__name__ if module else ""
+        if module_name.split(".")[-1] != "subs":
             logger.warning(
                 f"Subscription function {func.__module__}.{func.__name__} is "
                 "outside a subs module that will not be discovered."

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -3,15 +3,22 @@ import signal
 import socket
 import sys
 import time
+from collections.abc import Iterable
 from concurrent import futures
 from datetime import datetime
+from types import FrameType
+from typing import TYPE_CHECKING, Any, NoReturn
 
 from google.cloud.pubsub_v1.futures import Future
 from google.cloud.pubsub_v1.subscriber.scheduler import ThreadScheduler
 
 from .client import Subscriber
 from .middleware import run_middleware_hook
-from .subscription import Callback
+from .retry_policy import RetryPolicy
+from .subscription import Callback, Subscription
+
+if TYPE_CHECKING:
+    from rele.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +27,7 @@ class NotConnectionError(BaseException):
     pass
 
 
-def check_internet_connection(remote_server):
+def check_internet_connection(remote_server: str) -> bool:
     logger.debug("Checking connection")
     port = 80
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -48,15 +55,15 @@ class Worker:
 
     def __init__(
         self,
-        subscriptions,
-        client_options,
-        gc_project_id=None,
-        credentials=None,
-        gc_storage_region=None,
-        default_ack_deadline=None,
-        threads_per_subscription=None,
-        default_retry_policy=None,
-    ):
+        subscriptions: Iterable[Subscription],
+        client_options: dict[str, Any] | None,
+        gc_project_id: str | None = None,
+        credentials: Any = None,
+        gc_storage_region: str | list[str] | None = None,
+        default_ack_deadline: int | None = None,
+        threads_per_subscription: int | None = None,
+        default_retry_policy: RetryPolicy | None = None,
+    ) -> None:
         self._subscriber = Subscriber(
             gc_project_id,
             credentials,
@@ -65,20 +72,22 @@ class Worker:
             default_ack_deadline,
             default_retry_policy,
         )
-        self._futures: dict[str, Future] = {}
+        self._futures: dict[Subscription, Future] = {}
         self._subscriptions = subscriptions
         self.threads_per_subscription = threads_per_subscription
         self.internet_check_endpoint = self._get_internet_check_endpoint(client_options)
 
-    def _get_internet_check_endpoint(self, client_options):
+    def _get_internet_check_endpoint(
+        self, client_options: dict[str, Any] | None
+    ) -> str:
         if (
             client_options is not None
             and client_options.get("api_endpoint") is not None
         ):
-            return client_options.get("api_endpoint")
+            return str(client_options["api_endpoint"])
         return "www.google.com"
 
-    def setup(self):
+    def setup(self) -> None:
         """Create the subscriptions on a Google PubSub topic.
 
         If the subscription already exists, the subscription will not be
@@ -89,7 +98,7 @@ class Worker:
             self._subscriber.update_or_create_subscription(subscription)
         logger.debug("[setup] end setup")
 
-    def start(self):
+    def start(self) -> None:
         """Begin consuming all subscriptions.
 
         When consuming a subscription, a ``StreamingPullFuture`` is returned from
@@ -106,7 +115,7 @@ class Worker:
         run_middleware_hook("post_worker_start")
         logger.debug("[start] end start")
 
-    def run_forever(self, sleep_interval=1):
+    def run_forever(self, sleep_interval: float = 1) -> None:
         """Shortcut for calling setup, start, and _wait_forever.
 
         :param sleep_interval: Number of seconds to sleep in the ``while True`` loop
@@ -119,7 +128,9 @@ class Worker:
         self._wait_forever(sleep_interval=sleep_interval)
         logger.debug("[run_forever] finish")
 
-    def stop(self, signal=None, frame=None):
+    def stop(
+        self, signal: int | None = None, frame: FrameType | None = None
+    ) -> NoReturn:
         """Manage the shutdown process of the worker.
 
         This function has two purposes:
@@ -150,7 +161,7 @@ class Worker:
         run_middleware_hook("post_worker_stop")
         sys.exit(0)
 
-    def _boostrap_consumption(self, subscription):
+    def _boostrap_consumption(self, subscription: Subscription) -> None:
         logger.debug(f"[_boostrap_consumption][0] subscription {subscription.name}")
 
         if subscription in self._futures:
@@ -176,9 +187,9 @@ class Worker:
             )
             raise NotConnectionError
 
-        executor_kwargs = {"thread_name_prefix": "ThreadPoolExecutor-ThreadScheduler"}
         executor = futures.ThreadPoolExecutor(
-            max_workers=self.threads_per_subscription, **executor_kwargs
+            max_workers=self.threads_per_subscription,
+            thread_name_prefix="ThreadPoolExecutor-ThreadScheduler",
         )
         scheduler = ThreadScheduler(executor=executor)
 
@@ -193,7 +204,7 @@ class Worker:
             f"[{self._futures[subscription]._state}]"
         )
 
-    def _wait_forever(self, sleep_interval):
+    def _wait_forever(self, sleep_interval: float) -> None:
         logger.info("Consuming subscriptions...")
         while True:
             logger.debug(f"[_wait_forever][0] Futures: {self._futures.values()}")
@@ -220,7 +231,7 @@ class Worker:
             time.sleep(sleep_interval)
 
 
-def _get_stop_signal():
+def _get_stop_signal() -> signal.Signals:
     """
     Get stop signal for worker.
     Returns `SIGBREAK` on windows because `SIGSTP` doesn't exist on it
@@ -232,7 +243,7 @@ def _get_stop_signal():
     return signal.SIGTSTP
 
 
-def create_and_run(subs, config):
+def create_and_run(subs: list[Subscription], config: "Config") -> None:
     """
     Create and run a worker from a list of Subscription objects and a config
     while waiting forever, until the process is stopped.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,16 @@ class TestLoadSubscriptions:
         assert func_sub.name == "rele-test-topic"
         assert func_sub({"id": 4}, lang="en") == 4
 
+    def test_applies_filter_when_filter_by_is_a_single_callable(self):
+        subscriptions = load_subscriptions_from_paths(
+            ["tests.subs"],
+            sub_prefix="test",
+            filter_by=lambda attrs: attrs.get("lang") == "en",
+        )
+
+        assert subscriptions[0]({"id": 4}, lang="en") == 4
+        assert subscriptions[0]({"id": 4}, lang="es") is None
+
     def test_loads_subscriptions_when_they_are_class_based(self):
         subscriptions = load_subscriptions_from_paths(
             ["tests.subs"],

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.14'",
+    "python_full_version >= '3.15'",
+    "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
@@ -28,6 +29,47 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/12/3e5f575f156555547c250a8b0d1347517a3a20fc7f4492e9703a69d4f45e/ast_serialize-0.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:a7520b672827885bafeae7501f684d14d47d17e5f45256f9df547686cca52264", size = 1177640, upload-time = "2026-06-30T20:02:06.708Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a4/921a9e27951627983b0f368859ea00f8330a551dc0bf4c2fdcb11855a98b/ast_serialize-0.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a14191beec7e0c078d2fc1f6edc0aee88bcd4db9f18e1bc9f8052b559c22dddc", size = 1168111, upload-time = "2026-06-30T20:02:08.366Z" },
+    { url = "https://files.pythonhosted.org/packages/00/69/950cf404de7b8782cf95e5c1237e25e2aa46177b287f39f9eeddf481fd6f/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32ef62ec34cf6be20ad77d4799556638fbdf187f3ae10698dfb20ef9f2c89516", size = 1227656, upload-time = "2026-06-30T20:02:09.843Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a8/46f8f6a6479d9d2273980957bb091a506c55f5b95d3c029ee58518a78407/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:13b7769970a39983b0adf2f38917b1cd3b8946f76df045756c3d741bc689f089", size = 1227706, upload-time = "2026-06-30T20:02:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/b9/9ac415bda0a40e49eab8fea3b2741c19c98bb84d57d62c4cfc6230eb67be/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6f7a408601bb3edaefb3bc67a4c01f5235e3253653b6a5729a2ee2382b35341c", size = 1431705, upload-time = "2026-06-30T20:02:12.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/8807115d441444879f7561b5eede5ac18fc80392f11826d61ccf31f503b1/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8670bfa51208a2c0c8d138928e40e998fab158f9200d53bb80c088b5b8eda7b8", size = 1249533, upload-time = "2026-06-30T20:02:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c0/c2ba82ef9618650357d9421a1fdb27ffec862a7f57e8e2de82a3ccd11e12/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4826809eb8597a8cd59fd924b6d7c285b8969a1e0007e2cb652cab62376270f", size = 1252619, upload-time = "2026-06-30T20:02:16.219Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a7/fa31d52dd4102cede29fb9634e98d214129b2783b4f95528c6dc6a8f6587/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:577a6c189068686869f5f1ddc38363f3ae1808a4753b577266f9202071a7bb66", size = 1242983, upload-time = "2026-06-30T20:02:17.813Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/20/ddf742b5ad3c4bafd3466f2265037cfd99bc1b9a5ee46a5d58c90d523242/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:085de7f62dc9cc247eb01e965a362707d1d90b1d89a82c5bf78301a60a3c417b", size = 1296148, upload-time = "2026-06-30T20:02:19.146Z" },
+    { url = "https://files.pythonhosted.org/packages/24/cb/9f6f217cce8b3b632c5568b478d195a35e79dce4dbe309438cb89ba6ea4f/ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9f8a8b78b13173de6a9ec22111d9be674874cd5bdccda04f14ae5ebc2bef403a", size = 1403826, upload-time = "2026-06-30T20:02:20.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f8/9d16d4f0107a183924425cc0e7618d8bf76f96b45afa9ff19f924ed1ad57/ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f2ff3baffc3a29c1f15bc9098aa0c09763410262d5e6cef42116f7356c184554", size = 1502943, upload-time = "2026-06-30T20:02:22.034Z" },
+    { url = "https://files.pythonhosted.org/packages/80/dd/bbc1c38756350dddf7e24acae1c9482ef42051c267417e019aecc1ed4075/ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0067b25fce104eaae5b88383de9ab803faeb671831e14ca698b771b356e2600f", size = 1497632, upload-time = "2026-06-30T20:02:23.517Z" },
+    { url = "https://files.pythonhosted.org/packages/42/7e/9daffefcf5b97e6bb4c3e0b3c024c1aee9722f23d3cf7cd2ff80d6fb4a40/ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c617417f9cbb0cb144f6283c3cbe0d2e0f01beaf9f608f662b21191058a626ec", size = 1448858, upload-time = "2026-06-30T20:02:24.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1f/f9baaab81a677ea0af7d2458cac2f94ebcc85958f8a3c15ba9d9e5dab653/ast_serialize-0.6.0-cp314-cp314t-win32.whl", hash = "sha256:5337cb256dcea3df9288205213d1601581536526b8f4da44b6974f1180f3252a", size = 1052600, upload-time = "2026-06-30T20:02:26.263Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1f/41b535866519512d8cf6669cb2cff7823b7672bb6279c0333b4ff89d7d9f/ast_serialize-0.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2d947e45cafc4b09bd7528917fa84c517654a43de173c79785574b7b3068ac24", size = 1095570, upload-time = "2026-06-30T20:02:27.639Z" },
+    { url = "https://files.pythonhosted.org/packages/50/64/e472fe3e3a2d33d874b987e8518aedf24562919e3b6161a4fa1797e89c0f/ast_serialize-0.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:6e15ec740436e1a0d62de848641abe5f3a2f89a7f94907d534795ac91bbacf14", size = 1067267, upload-time = "2026-06-30T20:02:28.949Z" },
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
 ]
 
 [[package]]
@@ -480,7 +522,8 @@ name = "django"
 version = "6.0.7"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
+    "python_full_version >= '3.15'",
+    "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
 ]
@@ -511,7 +554,8 @@ name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
+    "python_full_version >= '3.15'",
+    "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
@@ -859,6 +903,93 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/2f/ec5241c38e7fa0fe6c26bfc450e78b9489a6c3c08b394b85d2c10e506975/librt-0.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:34e47058fcc69a313293d6dee94216a4f30c929ae6f2476e58c5ba635aa639d5", size = 148654, upload-time = "2026-07-08T12:24:30.622Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/1a/d651e18d3ee7aa2879322368c4f278bb7ecaa6b90caadfdec4ebfa8389f3/librt-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dbdd5b6509d0c2a8fe72cf494c299a61dbd58142a90a4190664ae159e4a7b547", size = 153537, upload-time = "2026-07-08T12:24:31.773Z" },
+    { url = "https://files.pythonhosted.org/packages/45/18/10bff2122577246009d9619b6569596daf69b7648812f997ca9ca0426f60/librt-0.13.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e56ea4ee4df77585a6b5c138f6538680886024fa559f5b55bd14b12e98e67b2", size = 494336, upload-time = "2026-07-08T12:24:33.079Z" },
+    { url = "https://files.pythonhosted.org/packages/67/69/87dfee871b852970f137fdeae8e2ca356c5ab38e6f21d2a3299535fc3159/librt-0.13.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f1f9cc4d09a46d9cb3c2063ae100629d3f52a6517c3c08c2f4c9828261883929", size = 485393, upload-time = "2026-07-08T12:24:34.324Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d5/625447a8c0441ff5f15f4ac5e1d323fb9d4d256ebfde7a3c8e003f646057/librt-0.13.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f125f5d46b20f89dc5587a55cc416b4ba2a5b2ffda36d048ee120e17598a653a", size = 515382, upload-time = "2026-07-08T12:24:35.575Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d8/1c8c49ea04235960426444deece9092a6b3a9587a850a81bae2335317411/librt-0.13.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2608d3b39f9e0b4a66a130d9150c615cba40a5090d25eeeaa225e0e46de8c0ac", size = 509483, upload-time = "2026-07-08T12:24:36.923Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/65/f1760fc48050e215201a03506c32b7270159088d01f64557b53e39e74a45/librt-0.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9fd35e95ab5e45c3901d37110263c7db85a961110f5460588fe37f8c131f88a7", size = 532503, upload-time = "2026-07-08T12:24:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1b/793e281dcf494879eff99f642b63ebc9c7c58694a1c2d1e93362a22c7041/librt-0.13.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5f31b0aa13c9b04370d4da6be1ab7779776b3a075cceb6747a39a4be85fe1e40", size = 537027, upload-time = "2026-07-08T12:24:39.34Z" },
+    { url = "https://files.pythonhosted.org/packages/69/45/0801bbb40c9eea795d3dd3ce91c4c5f3fe7d42d23ec4be3e8cb283bcc754/librt-0.13.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0b795f5fc70fbbb787ceaf79bb3a0d627bcc33c53de51741755263ec406b775a", size = 517100, upload-time = "2026-07-08T12:24:40.907Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6c/eb5f514f8e29d4924bc0ff4601dd7b4175557e182e7c0721e84cffa39b8a/librt-0.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:36b306a623aaad96fe4b378692b54f9c0789fccd833b9851753d5fbf6138cfde", size = 558653, upload-time = "2026-07-08T12:24:42.359Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bf/f140100d1b59fe87ff40b5ecbb4e27924335b189a784e230ee465452f6c2/librt-0.13.0-cp310-cp310-win32.whl", hash = "sha256:a3762e75fcac8c9e4dacaaf438bffd9003e2ca2c531b756f3c0035deefa674c8", size = 104402, upload-time = "2026-07-08T12:24:43.668Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7c/57e40fef7cfb61869341cb28bdcefe8a950bebcbecca74a397bae14dce4a/librt-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:d63bae12a8aeb51380be3438e4dc4bd27354d0f8e19166b2f44e3e94d6f552dc", size = 125002, upload-time = "2026-07-08T12:24:44.793Z" },
+    { url = "https://files.pythonhosted.org/packages/89/25/a6498964cfeec270c468cffdc118f69c29b412593610d55fa1327ca51ff4/librt-0.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1b5a7bbff495baedbd9b916c367d66854008f8f3b575908ded477c499dc60082", size = 148029, upload-time = "2026-07-08T12:24:45.961Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/dc86d1bffd8e0c2818bace29d9f7783cfbb8e0673bf3673b5bbd5bbe0420/librt-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:34bc7938b9fdf14fe32a406c19c71faf894c5cee7e7474bd0be2f17200b82d14", size = 153036, upload-time = "2026-07-08T12:24:47.257Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3f/b923826660f02f286186cd9303d52bb05ced0a13708edc104dc8480920e3/librt-0.13.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f40e56b61b41be5f7dec938cfeffd660668cf4b5e72c78e7bd671d66b7bc2c79", size = 493062, upload-time = "2026-07-08T12:24:48.483Z" },
+    { url = "https://files.pythonhosted.org/packages/88/87/6c0980a9c9b1302cb68d108906697b89eceb55889bb1dcf77c109aa56ca5/librt-0.13.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:9c5d02b89de5acd0379a51ec44a89476fb03df6145442e1c8ecd6bee2f91b176", size = 485510, upload-time = "2026-07-08T12:24:49.727Z" },
+    { url = "https://files.pythonhosted.org/packages/32/81/795ae3b9df5dd94079fb807e38191855e023e8c6249014ae6bc3f0d9a490/librt-0.13.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7db9a3ff32ef5f7d1703d93831a3316cdf0b537de6a1cc03cc8fdd09b9194e89", size = 515909, upload-time = "2026-07-08T12:24:51.135Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e5/182de15abce8907108a6fdb41487de65beb5099b74dc5841b19b099168db/librt-0.13.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3dbb2a31882456cadc7053378e81ad7ed7693db4ac9f98ab5f81ef034aa8ec9f", size = 508620, upload-time = "2026-07-08T12:24:52.358Z" },
+    { url = "https://files.pythonhosted.org/packages/32/03/33978d32db76e1f66377e8f78e42a2ca3c162143331677d1f50bbad36cfb/librt-0.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c6014e3c80f9c1fe268ef8b0e0ef113bac672cc032f2f93866e7ddad4f3e663d", size = 530363, upload-time = "2026-07-08T12:24:53.503Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f5/b291fbd2d00f7d8287bcbf67b5aa0c6afed4bc26cef23e079629c47a2c04/librt-0.13.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:091b60a4d2174fc1ec5c34cdc0b72efb6224753d76b7da61ebeab7a191aec8bd", size = 534209, upload-time = "2026-07-08T12:24:55.138Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/03/6f41f17939d191bc21609f220da8509316bc62797f078545fe83be522e78/librt-0.13.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:66cb1138f384a191a6d75f986064841fcfdc0cea98f7bd9c9ab9b38049917588", size = 514254, upload-time = "2026-07-08T12:24:56.276Z" },
+    { url = "https://files.pythonhosted.org/packages/af/c2/2e4befa5410a7443019c14abccc94ff619797171f6b72013635fb87f31d7/librt-0.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:17221a7569f8f292aa0014226e48aa25b8c2b08da18088cd230953d0ea0f9cd1", size = 557611, upload-time = "2026-07-08T12:24:57.561Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/54/8b69f81448417adbc040a2185f4e2eece1e1994b7dcfaeed4662b30f98a5/librt-0.13.0-cp311-cp311-win32.whl", hash = "sha256:fc67741da44c6eaa90e01eafb586bbba9b51eb5b6ed381ee6f5ae72eb3316d21", size = 104906, upload-time = "2026-07-08T12:24:58.806Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5a/f4aaf37b50f2fde12c8c663b83fdd499cdc24f957f19543d7414bfcc9e25/librt-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:cc99dfb62b23c9207c33d0be8a2e2af7a42e21e6ea388b380a0c948c7b88953b", size = 125852, upload-time = "2026-07-08T12:25:00.065Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/99/bf1820e6feeabc2f218c24450ec0c995d6a91e8ba0fd3caf042c9e8adb2a/librt-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:40ccd13c252d3fe473ffc8a57be7565abc8b64cf1b108344c859d5164f7f3e0c", size = 111832, upload-time = "2026-07-08T12:25:01.148Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+    { url = "https://files.pythonhosted.org/packages/67/3b/18e7b63255297a2bdc9c25c8d6d4ca8eca9f63aceb1252c0f7427ac7099e/librt-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a468951af16155824e88bdd8326ebe5bdb371f3ec0ac04642994b98201d914f3", size = 151027, upload-time = "2026-07-08T12:25:19.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/68/e2248452c00d1a03b45fee1752cdc8f790a476efd2402b75181da88a9e61/librt-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ae01d8512cc17079e53425635327dbf3f7ff57a42c00dec348bf79791c56444c", size = 155152, upload-time = "2026-07-08T12:25:20.851Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/16/52b1c99bf19057a062aac39c900cbb81499f6f75d6c537c14463d247ba78/librt-0.13.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32c26893cd085c1efe83219e78d866da23fb20a066101b8f68210004361d224c", size = 502499, upload-time = "2026-07-08T12:25:22.055Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/54/b811151805c795f55e0dedee6ec687b75f9982a8105d240ea3910737a77b/librt-0.13.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5929da1981a46bcf4b28b1b9499905f0ff58e2419da402a048234e9783acbc4b", size = 496108, upload-time = "2026-07-08T12:25:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f8/094d6b2bd93f3fdaa54db54cc788c4a365333bddad65ab02e04da0b1d004/librt-0.13.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:94b85d664d777bab6c0d709416cb42938251fda9e221b79e3a2215d85df5f4f9", size = 531576, upload-time = "2026-07-08T12:25:24.648Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/40/541733d5755824f968f7ec39d78ffbd75d145964157ae5e69a09ec6d7326/librt-0.13.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:531b2df3e9fe96b1fcf73a6d165921e4656be5f58d631d384ebce344298368db", size = 524390, upload-time = "2026-07-08T12:25:25.898Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/b5/255673cfdbf5ba663339d36cd863c897289ab4337577e19f9405ce059f36/librt-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:109b84a9edf69ad89dc1f66358659e14a031baca95e3e5b0060bd903ede8efd6", size = 543053, upload-time = "2026-07-08T12:25:27.436Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/11/ab5005e9c9850710f21e354201bf090646349d3fabf5f951eaf70235729e/librt-0.13.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1304368a3e7ffc3e9db986796cc5326fdb5943a3567ecc137cff318e4240c0e7", size = 546387, upload-time = "2026-07-08T12:25:28.65Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/04/a5d7ce1d1df1afd15ca283dcdf7530ac073e12d69ae8c40879dda96f7868/librt-0.13.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e4f9b472e7d308d94b62c801982065661158c6ed02790d6c7ddb4337cea0f9c1", size = 535970, upload-time = "2026-07-08T12:25:30.171Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/76/927e267a6daa290174ac281b23c9804c8829b042ade9c6f24a065f540958/librt-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f836c37478f167a81200d8c8b2c920a22224564bed2c23d7aeec760965c367a", size = 573582, upload-time = "2026-07-08T12:25:31.507Z" },
+    { url = "https://files.pythonhosted.org/packages/10/24/b6c5213efe39c19f9e13605644d0cf063b4ddaa33ac2e45b088e23a70e2e/librt-0.13.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:4000d961ff9598ac6ea603c6c836a5ed49bc205ade5fc378b998dfe1e2c36628", size = 82189, upload-time = "2026-07-08T12:25:32.675Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/00/d29736be177a906ac0b84a5b04b4fbfa22c776dc2f366de4172b0f968c08/librt-0.13.0-cp313-cp313-win32.whl", hash = "sha256:79e44cff71750d299d61a678e49995b0d5935a9cda238c2574daeca3ba536927", size = 106193, upload-time = "2026-07-08T12:25:33.692Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ac/aff6fb45393cb8912f39dfb156ef6b2d1cadb207ff465fc8f66141054be8/librt-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:54dab44a847d5ad1acd05c8a83fe518ae685516ecf4d3f7cc6e3df2a66767650", size = 126962, upload-time = "2026-07-08T12:25:34.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3a/d68cb2b334d53fd30fac81d3a489ce4ba0d9506f4df43fcf676b68352b19/librt-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:d4cb6fbfdf874340ab5e51450753c0f817b6958a3621125ee695bbc3de866566", size = 112127, upload-time = "2026-07-08T12:25:35.981Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/66/f49ae0d592bd45b6941e9a8bafcb6a87cddcd501ee7874707e767f01b585/librt-0.13.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:25218d94b1d2cbc0ba1d8a3f9dc9af578d9646e5ed16443a70cde1dfdcce6d71", size = 149818, upload-time = "2026-07-08T12:25:37.203Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/50/51c76d74014d04fb95b6506d286808984b78a2f7a41039094e6b2194ac48/librt-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f26629539d4893c2957a16c41bb058e1e135c1f150f6a2e25ed047f64cf3f5c6", size = 154071, upload-time = "2026-07-08T12:25:39.399Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fe/f19b0f5f82d5a1f2da736586bc840abd00ce07d6388136ae80b7333883fc/librt-0.13.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4517d47b2b8af26975a406fba7d314de9696d864252e0257c6ea90238cfe27f", size = 494168, upload-time = "2026-07-08T12:25:40.641Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bc/b8550c75775127fd31a5f20e8775997f7b527ad661fc8ddccd7497c064f7/librt-0.13.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f19e181de5b3a1148bb3420b8c4b0b0ea0fce6950099724ad151d6cea5acc180", size = 491054, upload-time = "2026-07-08T12:25:41.905Z" },
+    { url = "https://files.pythonhosted.org/packages/30/14/4d0204867623df3f33f86efd3d3692ba5e01321443f4d6eab35a22697618/librt-0.13.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22034924f5b42d5a56371cf271771bfeaabf235a7a8b6264bef2d20013f786c6", size = 523006, upload-time = "2026-07-08T12:25:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0a/c45fc9a260934696bace1ac5df1e148ac92bd71767aee3bf7cd7a4534f4c/librt-0.13.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c7897db4e95e22468bdda33d8e012ceacd0182abf001e6389d763f0def6286b9", size = 515058, upload-time = "2026-07-08T12:25:44.541Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/50c5ce45b326854ef8fa6ae4c36cf5142e5c55315eaf9e51d0ae73ac4da3/librt-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ce61b3746545029d4f5c17d6bd74b676254ad98433086c846ffb5e8fa73f007", size = 534025, upload-time = "2026-07-08T12:25:45.825Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2d/08c413c8f93fc13b8103624fce38e5caa86cd08cbbc8465870ab287af54b/librt-0.13.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:46c330e82565962c761dbce7941be2cff7db674ee807455a8d0cadc5f9b759b0", size = 540557, upload-time = "2026-07-08T12:25:47.059Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/93af71fb4a364952210051811dd4e40174e79656b050c89cacac18af3330/librt-0.13.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:375f5af8f99cbaa99dd293af986e3d57caabc9ba81a5d3f021603764854197a1", size = 523201, upload-time = "2026-07-08T12:25:48.392Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/6e/9766f07b676a4889d9f8bc2864e9ba5fff165653143ef4dda7df6aa34d16/librt-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9320d34c3376ae204b2cd176e8d4883a013934e0aef822f1aed9c536490c275d", size = 565740, upload-time = "2026-07-08T12:25:49.678Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/1e/664e3472ce2b6e10e9b83f29d4a36eb982ff6b5a169ae7567bba3a4c4ff5/librt-0.13.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:9af313c66157a69dc69ea0059a66961692250e0dc95af9c385a48ffb770a0d16", size = 81611, upload-time = "2026-07-08T12:25:50.857Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d4/8582a4d65e2234673685e07309d02c230b28a85724eb0acbf13f019b7f6e/librt-0.13.0-cp314-cp314-win32.whl", hash = "sha256:f2a7253458e34f33543551394ae4fe104b497ec2a65ac266074de64c1df82e37", size = 100106, upload-time = "2026-07-08T12:25:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ce/0cb99efe6086b46cd985dc26672166fae312a239690e75871f7fafbd3fc5/librt-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:a3dfe4edf10e8ed7e55b026a8bfc2c2a8704218b659cd4bffdf604fab966dc39", size = 121209, upload-time = "2026-07-08T12:25:53.166Z" },
+    { url = "https://files.pythonhosted.org/packages/26/85/4f3ccb083a3c9b0d42e223acdb3c3f507953324a59cdcab4826e8e2e3b89/librt-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:68a5faee4bba381cb93b5961f684a514cf0053cb92308ff9c792c2fea0b174c6", size = 106404, upload-time = "2026-07-08T12:25:54.253Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/77/333191499538c8e8189de7a4cba8e6f49ee949fd6d6e6324b21fd1522466/librt-0.13.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a38fb81d8376dfa2f8963b265fec07637802b0d01e2a127c19c66cb070fb24f5", size = 159231, upload-time = "2026-07-08T12:25:55.432Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/9e/2aa83758f22c278b837a1d8025898434ce2b8bff36678d5330ecaef56dff/librt-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d4c8d9bd5abce34b2e75edb3bf37ab0f34e49b1f915a40ae8468eb7c85bc5b46", size = 161300, upload-time = "2026-07-08T12:25:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c0/86791e936553ca763d6b3c2fb4d31d596cd00e14fa631c283a40ba01559a/librt-0.13.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:387e2f1d27e89bffe0d3f520f0da0662c973fd607ca16c1808f8a5085419485e", size = 582056, upload-time = "2026-07-08T12:25:58.144Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d3/a9ec15984a185e000c4d2a16ba28bd623124ad4c38a10974c7ff78e3a893/librt-0.13.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:4f6db193d2e5e0ed60359b9a5a682cd67205d0d3b1e459a867dd4b5c4e7eaa7a", size = 562758, upload-time = "2026-07-08T12:25:59.544Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/af/dbe36b78b19c06a55097f99305e4ea9458e2273e6ae16a3cbecaad7ee978/librt-0.13.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d38604854e8d22faadf683ec6c02bb0f886e2ba56ef981a1c36ee275f21ea22", size = 602095, upload-time = "2026-07-08T12:26:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a8/2966891b4dd2830f5203fbee92ac2c4947653a2390ba73dfa44244fad025/librt-0.13.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:371f7ce73026815dafd51c50ce38416e91428b28c4b2ec97cd39271164b0045c", size = 593452, upload-time = "2026-07-08T12:26:02.352Z" },
+    { url = "https://files.pythonhosted.org/packages/61/f5/4df8bfc8405ecf8c0d525b4d69636f694bdd8620b313ec8b76e54a5926cc/librt-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3aaedf52171bee90860704c560bc798fe83b76247df47568e0197e9b13c735a0", size = 623729, upload-time = "2026-07-08T12:26:04.294Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/13/9ac202dffc8db06f75d06c08c2f9f6ff054be67d21272dcc078fa1cc0c57/librt-0.13.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:96bad8725a4f196a798366c25ce075d1f7543a4ec045ffc13e6a7ec095cdab04", size = 617077, upload-time = "2026-07-08T12:26:05.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f0/ebe38610716aee5cb28efd95089bb90192096179802779381e1c5dcf239c/librt-0.13.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6bf6a559ffe4a93bbea6cf31ddf01a7fd9ba342ef51f27beb178e318b74acd61", size = 599561, upload-time = "2026-07-08T12:26:07.21Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5c/c2e72e236fff7abc716d5b1753b8b8cd3ea85ac46fe17d2e7c51d4e1c723/librt-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:301067672387902c55f94b51d5022304b36c966ea9fe1f21caab99a9bef487c9", size = 645511, upload-time = "2026-07-08T12:26:08.562Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/99/6203ce619dee940d6bfbe099ec3fe4be00a68e9d60f70abf906cf124fe66/librt-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:5fdcf34f86de8fb66d7dc7589f96ba91c4aa46671200d400e6fd6f109a483f18", size = 104357, upload-time = "2026-07-08T12:26:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/52/dd/843b6314087c41657c7036d7914d8f294bdf9b580aa8513ea0588c8e9a3d/librt-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:260c33e92263fa629b4f6d3c51967a1c2158fe6c33237aaa3ebeac586b085259", size = 126998, upload-time = "2026-07-08T12:26:10.975Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/3dcec2884ba1b0806d1408612555c38dd5d68e90156b59f75f6e36435c3a/librt-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2f281549a4c52ac7bb97997f14353f8bd0e53a34ca0dad1c905cfd0b4a58ae99", size = 110771, upload-time = "2026-07-08T12:26:12.303Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -974,6 +1105,75 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/09/f2f5f45dae0c9a0891e4751a73312730e009395102e5d72a22a976cca41f/mypy-2.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1fa8d916ac3b705af733c4c1e6c9ebe38fd0d52beb15b105c3e8355b55e6ecdc", size = 14927774, upload-time = "2026-07-13T11:28:38.224Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b9/345367effd3a6877275a94d481614bfca983f45e028c6290e2cc54603811/mypy-2.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:28e1e2af8cd8fff551fd30f2fe4b03fb76764ac8b1ba6c6a1bd00ad32b412db3", size = 14000127, upload-time = "2026-07-13T11:30:19.57Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6c/a10b7a7b9f0a755fb94e27ae834d4cea9ad6c5221f9325eef8f182641feb/mypy-2.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e77244df3843048c3f927182916730e40c124cbaa43905c1fb86cb382aa0805", size = 14229437, upload-time = "2026-07-13T11:28:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/bd/a26a602acb1bbf849fa4bdac4bc657ee2f11c0c2a764a2cc87a5304e865c/mypy-2.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9559ab18a9c9957dfa3004ab57cd4bac5f26a724329a9584e583367f0c2e1117", size = 15171457, upload-time = "2026-07-13T11:29:01.834Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/14/124f462bef69bcbc90b9358088460b6091954a3e004852fcd9948db617a5/mypy-2.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:09abd66d8685e73f8f7d17b847c3e104d9a7b164a8706ea87d6c96a3d45816d5", size = 15478281, upload-time = "2026-07-13T11:32:23.413Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a4/8bdca6a8ac8d856d82ed049144af2721245a135c2e8001d3890c93975852/mypy-2.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:5e91adad1ca81742ac7ef9893959911df867752206b37135185e88dfb3c89494", size = 11148008, upload-time = "2026-07-13T11:34:17.332Z" },
+    { url = "https://files.pythonhosted.org/packages/83/41/490eea348e60ba50decec20bc750605444149a5d7a8cc560042f90ba2c75/mypy-2.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:6f99ec626e3c3a2f7c0b22c5b90ddb5dabb1c18729c971e9bdaca1f1766d2cee", size = 10142329, upload-time = "2026-07-13T11:32:52.116Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b9/d75b3082b05f1b3028828aeb18e74ae5ab0a0936051bbf1f32f59f654747/mypy-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3419d00717afbc5265b50dd14b1278f29ea4884dd398ab67873489ac093fd329", size = 14838725, upload-time = "2026-07-13T11:32:44.655Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/50/79a65c6ea6e115bc73296038a4543b2d5c91f07912b918a2c616a2514bba/mypy-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cfca8ee88544090f86b6dcce05ec55d66eb48a762412ac2507810ba4bd793b6f", size = 13911128, upload-time = "2026-07-13T11:32:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/90/48/e11ed7716c26953ca321f726e452e374dbf81a6f2b8b212ec02af29b6b8f/mypy-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75cbb4b9ef04a0c84a957f07abc4504fbf64b8dcc145675101f2d3a78a4b1d6a", size = 14146742, upload-time = "2026-07-13T11:33:03.313Z" },
+    { url = "https://files.pythonhosted.org/packages/06/72/6807565b1c4861ef66f7fdd98b51c61556356eab80235717b46c53bb8627/mypy-2.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:982e3d53dd23d0a4cef67dd66791fdbede0cf38f9eb617bf47663554c51e1e36", size = 15081418, upload-time = "2026-07-13T11:31:13.899Z" },
+    { url = "https://files.pythonhosted.org/packages/00/80/1ea14c5d80e589e415973db3e47c78c2219a305b808b2b506395342c1d79/mypy-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:85c5385b93012ffa3b31479ab579aef5415f4f3a32c6cf1ae07a984d2a0ff461", size = 15328164, upload-time = "2026-07-13T11:31:35.723Z" },
+    { url = "https://files.pythonhosted.org/packages/37/28/8223157404a3d51920078459c37f80fbdc590e1d8ea049dc5ce48643022a/mypy-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:13b1b16e2fa39f3b2e33fb1c468abc7a69369fa2e886b4b87b5afc81472325cd", size = 11136472, upload-time = "2026-07-13T11:27:37.018Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/cc/ea27e5959c5f258585a756b252031f3b313583d81b5064b2bebc41d3706b/mypy-2.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:b5cd2f027a972a4a5f2278a11fac9747f5f81a53a30b714d74950b6807e55568", size = 10135800, upload-time = "2026-07-13T11:30:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ae/f7d056eb0294586a572d0d0d89580ec633c064db520f11d37d5a2fb833bd/mypy-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:91ad22a52ae2c7e621c2f67c94d5a17f66b3209a4cff5cf8a573579835c69e97", size = 14947298, upload-time = "2026-07-13T11:27:47.734Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d5/db3e7af01e7844d21662c6ddc1f7825ec7cb4053f0391ac02faf3638396f/mypy-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:99ac767cc5d3b64c8d0ae226ead10c96694f94e4e7da1668642225dcd4e75aac", size = 13950768, upload-time = "2026-07-13T11:27:57.726Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/fb/43c031f0190513d1ec248ed037eceb742ddd2a4d74bbf406658a28173837/mypy-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de6d2c484742a4d7b0ed6d07b143375624d3b899c5749c7b3c947f56261f48a6", size = 14151586, upload-time = "2026-07-13T11:29:18.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c3/f8b2ffc60883084da91be51af58e88a7ffd4ff9795acb7d902ff88d31eb1/mypy-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7da939dd335cfd2ad788bdfd081c9f4e47634ab995e5a45eb15fd1e5bc052f8b", size = 15227411, upload-time = "2026-07-13T11:30:29.904Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2e/16b917fc7adcf03f1aadddfc93aab804ffb234b1ab09c0ffd6d92a5d34a2/mypy-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7247eb2824f996722a949530183394921ca71deb9680052a338cf53cff7925c2", size = 15478790, upload-time = "2026-07-13T11:33:14.686Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/88/aaa65a93c73d0cdae7e42f8adb302bf6885bb281302084f99d0290a35347/mypy-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:75b0984bb3cbd76bb5c9291a8671f7ae66ca3b51c7584c358fc2e923259f0757", size = 11234919, upload-time = "2026-07-13T11:33:39.28Z" },
+    { url = "https://files.pythonhosted.org/packages/35/19/b40de63f1a80e63bc2d40f0679a6a8dbd34e95176c8122119bdf406aa552/mypy-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:d78fcf900b59cb7e82cb7e3a235e31b462d9333d92285bd1e4952d355b8ffba1", size = 10201510, upload-time = "2026-07-13T11:31:52.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/58/fa0ae047da911f540284009b4f44b96fe09d83c076d7c103e9d645f46303/mypy-2.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ea317b060ce83e26050f8f9e4d7d6bf44ed7597c8ff9990bccffbb9d1d8522db", size = 14941909, upload-time = "2026-07-13T11:32:34.332Z" },
+    { url = "https://files.pythonhosted.org/packages/15/14/2ba1d61452d7c2a7fe12741e8d374e52b183476b07aa7f9e2a0d02b0720a/mypy-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:094af99f92638aa92852326188b85a89e50f4a472f44827c03362228482f0762", size = 13967581, upload-time = "2026-07-13T11:30:00.587Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/5a/483fb9e5ffbbb1a28dccc7b0a13d141b17ac769b6c9f488c0a0c63698962/mypy-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de121747278144fc9ae7caa2e978cf5df12aebc82933182f5b3b86081a30baef", size = 14168807, upload-time = "2026-07-13T11:28:48.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/77/70d7a10732063beb74ad713682cf871e88f5c5fa39bfc8beff8a524bf9cb/mypy-2.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:37fa4de896a84e2dc9200d91e614c22563b43d1a266789d4bbac7b22ebe6192b", size = 15200144, upload-time = "2026-07-13T11:31:25.283Z" },
+    { url = "https://files.pythonhosted.org/packages/56/72/766218ac783be4fdfcd699b90037b63017348a3e86fb2c1fbfb18302637d/mypy-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f1b3a98dfd21058bc759bb3337d5d1f61d0fdf9f3cf9c00f4291790fb5427bff", size = 15460389, upload-time = "2026-07-13T11:29:29.077Z" },
+    { url = "https://files.pythonhosted.org/packages/38/4e/8a9db7411ecb8ec0cb1fd05dba432f28bafffcd38b4e887714a4a0506689/mypy-2.3.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:944c665d984157cb96a679dfb7a4a81dd1d36b24b9c284b699514e6e626b82d4", size = 7753664, upload-time = "2026-07-13T11:29:08.147Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4c/c3f8bfd6ed0e5e38b5a244403b27f821d433443df5a15a278417c10a3a3c/mypy-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:4359424140d985192c778c1ce2c114a10c1ca58a381ed79cfa70d37df94b299f", size = 11417237, upload-time = "2026-07-13T11:33:47.467Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/00/89a32eaf5ccf174bc4f90db0eaea5d70636c01b8d49f384bdab2e8834390/mypy-2.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:3dd0bed92c4bdec57c42505b96416fb9e6a5aa7be84d2809bcd5f2ecec2860d7", size = 10389252, upload-time = "2026-07-13T11:31:43.81Z" },
+    { url = "https://files.pythonhosted.org/packages/31/56/104f93d69aa9f339b6b9d3b0a7faa699b8b466c942cf3ae86cc2a2ec0915/mypy-2.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:691fdc37132b1ae628d834f672e74de83462d9fb4aff621835767fb43a8dd373", size = 16385495, upload-time = "2026-07-13T11:29:49.818Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/03/f1d2123313f55efafdd27706960f43a771c62f1b68426c76043f3ab9ebf3/mypy-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:aec15d465d477558fd842757b487849007311cf3897849cdda0e3162ac0ac556", size = 15098155, upload-time = "2026-07-13T11:30:40.301Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/5d/d5f9200399b445e81726c4f23becee33f233aee81c72680b1ef3a258b641/mypy-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b352b7e49f5e6576009e8df730e1ff4f915cb565b851b396d2ffe2f5a6f5da88", size = 15514155, upload-time = "2026-07-13T11:34:38.569Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ce/69977c555f08faa3190cfde44189b89dbd56861b1ab97aa18fc5f3a2e4a3/mypy-2.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c6c6bf687b17f90dbfcad95b960d32eaa0154c00da45f03ab50bf8952e047fe", size = 16766351, upload-time = "2026-07-13T11:33:29.195Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/92/6648b6caa3ab9e00f9ac0c2a78307805f873dd48139b24a6f6f7c3667bbf/mypy-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f4ed18f111bfe2d599bca7468e7f9251042c1c2118f762c8de2766a56d773c60", size = 17043490, upload-time = "2026-07-13T11:30:53.927Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ab/0dc91d80f3f016634c68d451f294a97320fe903a9b6f90b9e57b3f7f1717/mypy-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0b025a93cffb9781d231f232be07a17912f35f10a313c24f301c81e842870654", size = 12146869, upload-time = "2026-07-13T11:29:38.874Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b5/4c964d02634ba81f4d1c84838e5c5b18ab06d13ed568960f5d6318495ccc/mypy-2.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:adebc76aab4f3495a88b41d48aa4aff0c03f2822501da76625afcca5975f19e5", size = 10965113, upload-time = "2026-07-13T11:28:07.056Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "nh3"
 version = "0.3.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1053,6 +1253,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -1243,6 +1452,7 @@ test = [
     { name = "django", version = "5.2.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "freezegun" },
+    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-django" },
@@ -1269,6 +1479,7 @@ test = [
     { name = "coverage", specifier = ">=4.4.0" },
     { name = "django" },
     { name = "freezegun", specifier = "==1.5.5" },
+    { name = "mypy", specifier = "==2.3.0" },
     { name = "pytest", specifier = "==8.4.2" },
     { name = "pytest-cov", specifier = ">=2.7.0" },
     { name = "pytest-django", specifier = ">=4.5" },
@@ -1463,7 +1674,8 @@ name = "sphinx"
 version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
+    "python_full_version >= '3.15'",
+    "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
 ]


### PR DESCRIPTION
## Description

Closes #308 (last piece of #304 together with #309).

The whole `rele` package is now fully annotated and passes **mypy 2.3.0 in strict mode** (`disallow_untyped_defs`, `warn_return_any`, etc. — config as agreed). A `py.typed` marker ships in the wheel (PEP 561), so users get the types in IDEs and their own type checkers.

- `[tool.mypy]` scoped to the `rele` package via `files` (tests stay unchecked, standard practice with strict mode).
- `make typecheck` target, wired into CI between linting and coverage.
- Google/Django objects are typed as `Any` where their libraries expose no types; two targeted `type-ignore`s document stub mismatches and say why.
- `Worker._futures` was annotated `dict[str, Future]` but is actually keyed by `Subscription` objects — the annotation now matches reality.

## 🐛 Bug found while typing: `FILTER_SUBS_BY` with a single callable crashed

Typing the API surfaced a **real latent bug**, fixed in its own commit (`701fce8`):

- **Symptom**: configuring `FILTER_SUBS_BY` with a bare boolean function — the exact form shown in [the settings docs](https://mercadonarele.readthedocs.io/en/latest/settings.html#filter-subs-by) (`'FILTER_SUBS_BY': boolean_function`) — made every subscriber crash with `TypeError` on the **first message received**.
- **Cause**: `load_subscriptions_from_paths` passes the raw setting to `Subscription.set_filters`, which stored it as-is; `_any_filter_returns_false` then iterates `self._filters`, and a function is not iterable. The `Subscription.__init__` path normalizes through `_init_filters`, but the `set_filters` path never did.
- **Why it survived since 2020**: the test suite only exercised the list form (`filter_by=[func]`), which works on both paths.
- **Fix**: `set_filters` now normalizes through `_init_filters`, same as the constructor. Regression test added covering the single-callable form (`test_applies_filter_when_filter_by_is_a_single_callable`).

## Behavior-preserving adjustments worth a look in review
- `LoggingMiddleware.__init__` initializes its logger instead of `None` (setup re-assigns it, as before).
- `publishing.publish` asserts the global publisher exists after setup (previously an `AttributeError` on `None` in the same impossible case).
- `filter(None, ...)` instead of `filter(lambda x: x, ...)` in `Subscription.name` (identical semantics, lets mypy narrow).

## Testing

- `make typecheck` — no issues in 22 source files.
- `make lint` green; full suite **103 passed** (102 + new regression test).
- `py.typed` verified present in the built wheel.

Generated with Claude Code
