### PR TITLE
chore: cut 1.17.0b1 pre-release and add manual publish dispatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,9 @@ name: Release Please
 on:
   push:
     branches: [master]
+  # Manual escape hatch: builds the selected ref and publishes it to PyPI
+  # through the same trusted-publishing environment. Used for pre-releases.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -10,6 +13,7 @@ permissions:
 
 jobs:
   release-please:
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -19,12 +23,16 @@ jobs:
         id: release
 
   publish:
-    # Runs only when the release PR is merged and the GitHub release created.
+    # Runs when the release PR is merged and the GitHub release created, or
+    # when the workflow is dispatched manually (pre-releases).
     # Publishing uses PyPI trusted publishing (OIDC): the "pypi" environment
     # and the trusted publisher for this repo/workflow must be configured on
     # https://pypi.org/manage/project/rele/settings/publishing/
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: >-
+      ${{ always() &&
+          (github.event_name == 'workflow_dispatch' ||
+           needs.release-please.outputs.release_created == 'true') }}
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -32,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ needs.release-please.outputs.tag_name || github.ref }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7

--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.16.0"  # x-release-please-version
+__version__ = "1.17.0b1"  # x-release-please-version
 
 try:
     import django


### PR DESCRIPTION
## Description

Prepares a **pre-release (`1.17.0b1`)** so this cycle's modernization (Python >= 3.10, 3.13/3.14 support, hatchling, uv, ruff, mypy strict + `py.typed`, plus the `FILTER_SUBS_BY` bug fix) can be validated against an internal service before the first automated release. Pre-releases are invisible to pip unless pinned explicitly (`rele==1.17.0b1`), so regular users are unaffected.

- `rele/__init__.py` bumped to `1.17.0b1`. release-please is unaffected: it tracks `.release-please-manifest.json` (still `1.16.0`) and will overwrite the annotated version line when the first real release PR lands (which should be **at least a minor** given the dropped Python versions).
- `workflow_dispatch` trigger added to `release-please.yml`: a manual run builds the selected ref with `uv build` and publishes through the **same trusted-publishing environment** (the publisher is bound to this workflow file + `pypi` environment, so it must live here, not in a separate file). Doubles as a break-glass manual publish path.
- The `release-please` job is now gated to `push` events so a manual dispatch goes straight to publish.

## Release steps after merging

1. `gh workflow run release-please.yml` (or Actions → Release Please → Run workflow, branch `master`)
2. Verify `rele==1.17.0b1` on PyPI and install it in the internal service.

## Testing

- Workflow validated against the GitHub Actions schema.
- `uv build` produces `rele-1.17.0b1-py3-none-any.whl` / `.tar.gz` (valid PEP 440).
- Full suite: 103 passed.

Generated with Claude Code