### PR TITLE
chore: release the pending changes as 1.17.0 with v-style tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,8 @@
       "package-name": "rele",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
+      "release-as": "1.17.0",
       "extra-files": ["rele/__init__.py"]
     }
   }


### PR DESCRIPTION
## Description

The auto-created release PR (#323) proposes **1.16.1**, but the pending release includes dropping Python < 3.10 and the toolchain modernization already being validated as `1.17.0b1` — it must ship as **1.17.0**. Two config changes:

- `"release-as": "1.17.0"` — release-please will retarget #323 to 1.17.0 on its next run. **Remove this line right after 1.17.0 ships** (it's a one-shot override; leaving it would pin every future release to 1.17.0).
- `"include-component-in-tag": false` — the release PR was going to tag `rele-v1.17.0`; this makes it `v1.17.0`, matching the repo's historical style.

## What to do with #323

**Don't close it** — release-please recreates managed release PRs on every push. The plan: merge this config PR now, let #323 update itself to 1.17.0, and **leave #323 unmerged until the `1.17.0b1` validation in the internal service finishes**. Merging #323 is the release trigger.

Generated with Claude Code