### PR TITLE
chore: reset version to last released 1.16.0

### DIFF
--- a/rele/__init__.py
+++ b/rele/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.17.0b1"  # x-release-please-version
+__version__ = "1.16.0"  # x-release-please-version
 
 try:
     import django


### PR DESCRIPTION
## Problem

The `1.17.0b1` pre-release (#320) left `rele/__init__.py` at a PEP 440 pre-release string. That silently breaks the release PR (#323):

- release-please's generic updater matches the semver prefix `1.17.0` **inside** `1.17.0b1` and rewrites it with the same `1.17.0` — the `b1` suffix survives, so the file shows **no diff** and never gets bumped.
- `pyproject.toml` builds via `[tool.hatch.version] path = "rele/__init__.py"`, so merging #323 as-is would create tag `v1.17.0` but `uv build` would produce `rele-1.17.0b1` — already on PyPI — and `gh-action-pypi-publish` would fail with *file already exists*, burning the tag without publishing 1.17.0.

## Fix

Reset to `1.16.0`, the last released version. This restores the invariant `docs/ai/release-process.md` assumes: the file tracks what was last published, and release-please bumps it in the release PR. After merging, #323 regenerates with the `1.16.0` → `1.17.0` bump included, and the build produces the right artifact.

`chore:` title so release-please ignores this commit for version calculation.

Generated with Claude Code