### PR TITLE
chore: backfill the 1.17.0 changelog and drop the release-as override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## [1.17.0](https://github.com/mercadona/rele/compare/1.16.0...v1.17.0) (2026-08-05)
 
+First fully automated release, and the first since 1.16.0 (2025-07-25). Ships
+the same code as the `1.17.0b1` pre-release plus the two documentation changes
+below.
+
+> Every entry except the Documentation ones was **backfilled by hand**. The
+> modernization work landed before this repo adopted Conventional Commits (it
+> used the legacy `[Added]`/`[Changed]`/`[Fixed]` prefixes) and predates
+> `bootstrap-sha`, so release-please could not derive it from the commit
+> history and generated a documentation-only changelog.
+
+### ⚠ BREAKING CHANGES
+
+* **Python 3.8 and 3.9 are no longer supported.** `requires-python` moved from
+  `>=3.8` to `>=3.10`, and support now extends through Python 3.14. Installing
+  on 3.8 or 3.9 fails at dependency resolution instead of at runtime
+  ([#312](https://github.com/mercadona/rele/issues/312)) ([da1c36c](https://github.com/mercadona/rele/commit/da1c36c8633868444c2899a27b50882756d5d925))
+
+### Features
+
+* type hints for the public API, checked by mypy strict; `rele/py.typed` ships in the wheel ([#317](https://github.com/mercadona/rele/issues/317)) ([5879fee](https://github.com/mercadona/rele/commit/5879fee5f58ce253244d70e397c86e0aa163a468))
+* automate releases with release-please and PyPI trusted publishing ([#318](https://github.com/mercadona/rele/issues/318)) ([5c2ee4a](https://github.com/mercadona/rele/commit/5c2ee4a77af1c1422f94c15019a5460716582050))
+
+### Bug Fixes
+
+* move return out of finally block in `check_internet_connection` ([#303](https://github.com/mercadona/rele/issues/303)) ([3beb3fc](https://github.com/mercadona/rele/commit/3beb3fc7cc21f79db021910b527c4c240bea1a10))
+* stop the worker-stop test from racing a real Pub/Sub connection ([#316](https://github.com/mercadona/rele/issues/316)) ([7753e0c](https://github.com/mercadona/rele/commit/7753e0c860fccc54998e3d8b95901d045735b0ec))
+
+### Build System
+
+* move packaging metadata to pyproject.toml ([#310](https://github.com/mercadona/rele/issues/310)) ([30cc7fd](https://github.com/mercadona/rele/commit/30cc7fd0dcb2a28cde47c03eedfcd177c9ff10ec))
+* switch build backend to hatchling with SPDX license expression ([#313](https://github.com/mercadona/rele/issues/313)) ([fe0d2d4](https://github.com/mercadona/rele/commit/fe0d2d4c8fbbe20cc198b3cb2dc76d139ab75ba8))
+* adopt uv: dependencies live in pyproject.toml, requirements/ removed ([#314](https://github.com/mercadona/rele/issues/314)) ([6a25272](https://github.com/mercadona/rele/commit/6a25272fbae1376415f66e33e4e56d4d73b6e2ac))
+* replace black and isort with ruff ([#315](https://github.com/mercadona/rele/issues/315)) ([467de69](https://github.com/mercadona/rele/commit/467de698d5bc41c1dce69ce6d423409231db9dff))
 
 ### Documentation
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,6 @@
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
       "include-component-in-tag": false,
-      "release-as": "1.17.0",
       "extra-files": ["rele/__init__.py"]
     }
   }


### PR DESCRIPTION
Two post-release cleanups for 1.17.0 (published to PyPI in #326).

## 1. Backfill `CHANGELOG.md`

release-please generated a **documentation-only** changelog for 1.17.0, which under-reports the release badly — the headline change is dropping Python 3.8/3.9 support, and it wasn't mentioned at all.

Why it happened: the modernization work (#303, #310, #312–#318) uses the legacy `[Added]`/`[Changed]`/`[Fixed]` prefixes instead of Conventional Commits, and sits at or before `bootstrap-sha` (`5879fee`, = #317). release-please could therefore neither derive changelog entries from it nor compute a minor bump — which is exactly why the `release-as` override was needed in #324. Of the commits it *did* see, only #321 and #322 are `docs:`; the rest are `chore:`, a hidden section.

The pre-release contributed nothing either: `1.17.0b1` was published via `workflow_dispatch`, which skips the release-please job entirely, so no changelog was ever generated for it. The [v1.17.0b1 release notes](https://github.com/mercadona/rele/releases/tag/v1.17.0b1) were written by hand and release-please doesn't read release bodies.

Backfilled entries are marked as such in the file. Verified range: 1.16.0 is the code at `0a38df7` (both dated 2025-07-25), so everything listed genuinely landed after it — nothing is attributed twice.

**This is a deliberate one-off exception to the "never edit CHANGELOG.md by hand" rule in CLAUDE.md.** It's safe: release-please only *prepends* new version sections, so the edited 1.17.0 section survives future releases.

The GitHub release notes for `v1.17.0` are being updated to match.

## 2. Drop `"release-as": "1.17.0"`

#324 added it as a one-shot override and its own description called for removing it right after 1.17.0 shipped. This is now a **prerequisite**, not just hygiene: with the manifest at 1.17.0, leaving it in would make release-please target 1.17.0 again on the next push to master — against a tag that already exists.

Going forward this won't recur: CLAUDE.md mandates Conventional Commits in PR titles, and `bootstrap-sha` is now behind us.

Generated with Claude Code