### PR TITLE
docs: document the release-please pre-release trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ the same code as the `1.17.0b1` pre-release plus the two documentation changes
 below.
 
 > Every entry except the Documentation ones was **backfilled by hand**. The
-> modernization work landed before this repo adopted Conventional Commits (it
-> used the legacy `[Added]`/`[Changed]`/`[Fixed]` prefixes) and predates
-> `bootstrap-sha`, so release-please could not derive it from the commit
-> history and generated a documentation-only changelog.
+> modernization work landed before this repo adopted Conventional Commits — it
+> used the legacy `[Added]`/`[Changed]`/`[Fixed]` prefixes, which release-please
+> skips entirely — so it saw only the two `docs:` commits and generated a
+> documentation-only changelog.
 
 ### ⚠ BREAKING CHANGES
 

--- a/docs/ai/gotchas.md
+++ b/docs/ai/gotchas.md
@@ -25,6 +25,35 @@ packaging, CI, linting or the worker.
   ruff ignores them — long URLs in docstrings go in RST link-target blocks
   instead.
 
+## Releases
+
+Full flow in `release-process.md`; these are the traps that actually bit.
+
+- **Reset `rele/__init__.py` right after every manual pre-release.** Leaving a
+  PEP 440 pre-release string there silently breaks the next release PR:
+  release-please's generic updater matches the semver prefix `1.17.0` *inside*
+  `1.17.0b1` and rewrites it with the same `1.17.0`, so the `b1` suffix
+  survives and the file shows **no diff**. hatchling then builds the
+  pre-release version under the new tag and PyPI rejects it as already
+  existing — tag burned, nothing published (broke the 1.17.0 release,
+  PRs #325–#327).
+- **release-please won't refresh a release PR** whose target version and
+  changelog are unchanged — it compares those, not the file tree. A release PR
+  branched off an older master keeps stale contents forever. Force it: close
+  the PR, delete its branch, re-run the workflow.
+- **Check the release PR's diff includes the `rele/__init__.py` bump** before
+  merging it. That one line is what the wheel version comes from; the manifest
+  and changelog changes are cosmetic by comparison.
+- **`release-as` is one-shot.** Remove it as soon as the version it forced has
+  shipped, or the next push targets an already-tagged version.
+- Commits that aren't Conventional Commits are invisible to release-please —
+  no changelog entry *and* no version bump. The pre-2026-07 history uses
+  `[Added]`/`[Changed]`/`[Fixed]`, which is why 1.17.0 needed both a forced
+  version and a hand-written changelog. This bites regardless of
+  `bootstrap-sha`: release-please anchors on the newest prior release tag when
+  there is one, and drops non-conforming commits inside that range on their
+  titles alone.
+
 ## Code
 
 - `FILTER_SUBS_BY` accepts a single callable **or** an iterable; both

--- a/docs/ai/release-process.md
+++ b/docs/ai/release-process.md
@@ -18,11 +18,35 @@ long-lived tokens.
 
 `release-please.yml` also has a `workflow_dispatch` trigger: it skips the
 release-please job and publishes the selected ref directly through the same
-trusted-publishing environment. Used for `1.17.0b1` (PR #320). Recipe: PR
-bumping `rele/__init__.py` to a PEP 440 pre-release (e.g. `1.18.0b1`) with a
-`chore:` title (so release-please ignores it), merge, then
-`gh workflow run release-please.yml --ref master`. Pre-releases are only
-installed with an exact pin (`rele==1.18.0b1`).
+trusted-publishing environment. Used for `1.17.0b1` (PR #320).
+
+Recipe:
+
+1. PR bumping `rele/__init__.py` to a PEP 440 pre-release (e.g. `1.18.0b1`)
+   with a `chore:` title, so release-please ignores it.
+2. Merge, then `gh workflow run release-please.yml --ref master`.
+3. **Immediately open a second `chore:` PR resetting `rele/__init__.py` back
+   to the last released version.** Skipping this breaks the next real
+   release — see below.
+
+Pre-releases are only installed with an exact pin (`rele==1.18.0b1`), and
+`workflow_dispatch` creates no tag or GitHub release, so back-fill those by
+hand if you want the pre-release visible on GitHub.
+
+### Why step 3 is mandatory
+
+Leaving a pre-release string in `rele/__init__.py` silently breaks the next
+release PR. release-please's generic updater matches the semver prefix
+`1.18.0` *inside* `1.18.0b1` and rewrites it with the same `1.18.0`, so the
+`b1` suffix survives and the file shows **no diff**. Since hatchling reads the
+build version from that file, merging the release PR tags `vX.Y.Z` but builds
+the pre-release version, and PyPI rejects it as already existing — burning the
+tag without publishing anything. Cost a broken release during 1.17.0
+(PRs #325–#327).
+
+Invariant to check before merging any release PR: `rele/__init__.py` and
+`.release-please-manifest.json` must agree on the last *released* version, and
+the release PR's diff must contain the bump of `rele/__init__.py`.
 
 ## Wiring details
 
@@ -36,12 +60,36 @@ installed with an exact pin (`rele==1.18.0b1`).
   run on it (GitHub restriction). It only touches version + changelog.
 - Requires the org/repo Actions setting "Allow GitHub Actions to create and
   approve pull requests" to stay enabled.
+- release-please **does not refresh an existing release PR** when the target
+  version and changelog are unchanged — it compares those, not the tree. A
+  release PR branched off an older master therefore keeps stale file contents
+  indefinitely. To force a regeneration: close the PR, delete its branch, then
+  re-run the workflow (`gh run rerun <id>`); it recreates the PR from current
+  master.
+- `release-as` is a **one-shot override**: remove it in the same breath as the
+  release it forced. Left in place, the next push targets a version that is
+  already tagged.
 
 ## History quirks
 
-- PyPI history: 1.16.0 was published without a changelog entry or git tag
-  (tags stopped at v1.9.0). CHANGELOG.rst is frozen; CHANGELOG.md is the
-  live one.
-- The changes between 1.16.0 and the first automated release include
-  dropping Python < 3.10 — that release should be at least a minor
-  (`release-as` in the config can force a specific version).
+- Tag naming is inconsistent across history: `v1.4.1` … `v1.15.3` carry the
+  `v`, then **`1.16.0` does not** (it points at `0a38df7`), then `v1.17.0`
+  onwards does again — that is what `include-v-in-tag` now pins. 1.16.0 was
+  published to PyPI without a changelog entry. CHANGELOG.rst is frozen;
+  CHANGELOG.md is the live one.
+- **1.17.0** (2026-08-05) was the first automated release. Its changelog had
+  to be **backfilled by hand** — a deliberate, documented exception to the
+  "never edit CHANGELOG.md" rule (PR #327). Cause: the modernization work
+  (#303, #310, #312–#318) uses the legacy `[Added]`/`[Changed]`/`[Fixed]`
+  prefixes, so release-please skipped every one of those commits — no
+  changelog entry *and* no version bump. It saw only the two `docs:` commits
+  (#321, #322), proposed a **patch** (1.16.1), and generated a
+  documentation-only changelog omitting the headline breaking change
+  (dropping Python 3.8/3.9). `release-as: "1.17.0"` forced the version (#324)
+  and was removed once it shipped (#327). Hand-edits to past sections are
+  safe — release-please only *prepends* new version sections.
+  Note `bootstrap-sha` was **not** the operative cause here: release-please
+  anchored on the existing `1.16.0` tag (hence the `1.16.0...v1.17.0` compare
+  link), so those commits were inside the range it scanned and were dropped
+  purely on their titles. `bootstrap-sha` only applies when no prior release
+  tag is found.


### PR DESCRIPTION
Follow-up to #325–#327. The pre-release recipe in `docs/ai/release-process.md` told you to bump `rele/__init__.py` to a PEP 440 pre-release but never to reset it, so the failure landed on whoever cut the next real release — exactly what happened with 1.17.0.

## `docs/ai/release-process.md`

- Pre-release recipe is now a 3-step list with **resetting `rele/__init__.py`** as a mandatory step, plus a "Why step 3 is mandatory" section: the generic updater matches the semver prefix `1.18.0` *inside* `1.18.0b1` and rewrites it with itself, so the file shows no diff, hatchling builds the pre-release version under the new tag, and PyPI rejects it as already existing — tag burned, nothing published.
- States the invariant to check before merging any release PR: `rele/__init__.py` and `.release-please-manifest.json` must agree on the last *released* version, and the PR diff must contain the `rele/__init__.py` bump.
- Two more traps under "Wiring details": release-please **does not refresh** a release PR whose target version and changelog are unchanged (it compares those, not the tree — a stale branch stays stale until you close the PR, delete the branch and re-run), and `release-as` is a one-shot override.
- Notes that `workflow_dispatch` creates no tag or GitHub release.

## `docs/ai/gotchas.md`

New "Releases" section with the same traps in checklist form, cross-referencing `release-process.md`.

## Corrections to existing content

Two claims under "History quirks" were wrong, and I verified both against the repo:

- *"tags stopped at v1.9.0"* — they run through `v1.15.3`.
- *"1.16.0 was published without a git tag"* — the tag exists, it just lacks the `v` prefix (`1.16.0` → `0a38df7`). That inconsistency is precisely what `include-v-in-tag` now pins.

I also pinned down the real cause of the thin 1.17.0 changelog, which I'd previously attributed partly to `bootstrap-sha`. It wasn't: release-please anchored on the existing `1.16.0` tag — hence the `1.16.0...v1.17.0` compare link — so #303/#310/#312–#318 *were* inside the range it scanned and were dropped purely for not being Conventional Commits. `bootstrap-sha` only applies when no prior release tag is found. Wording corrected in `CHANGELOG.md` too (already a hand-maintained section per #327).

Generated with Claude Code