### PR TITLE
fix: emit the connection-check error log instead of losing it

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,3 +16,4 @@ Thank you to all the contributors to Relé!
 * Chirag Jain (@chirgjin-les)
 * Jordi Chulia (@jorchube)
 * Emilio Carrión (@EmilioCarrion)
+* Miro (@Mirochill)

--- a/rele/worker.py
+++ b/rele/worker.py
@@ -38,7 +38,7 @@ def check_internet_connection(remote_server: str) -> bool:
         sock.connect((remote_server, port))
         result = True
     except (TimeoutError, OSError, socket.herror, socket.gaierror) as error:
-        logger.exception("Check internet connection error", error)
+        logger.exception("Check internet connection error: %s", error)
     finally:
         sock.close()
     return result

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,3 +1,4 @@
+import socket
 import time
 from concurrent import futures
 from concurrent.futures._base import FINISHED
@@ -13,7 +14,7 @@ from rele import Subscriber, Worker, sub
 from rele.middleware import register_middleware
 from rele.retry_policy import RetryPolicy
 from rele.subscription import Callback
-from rele.worker import NotConnectionError, create_and_run
+from rele.worker import NotConnectionError, check_internet_connection, create_and_run
 
 
 @sub(topic="some-cool-topic", prefix="rele")
@@ -201,6 +202,27 @@ class TestWorker:
         mock_internet_connection.assert_called_once_with(
             "custom-api.interconnect.example.com"
         )
+
+
+class TestCheckInternetConnection:
+    @patch("rele.worker.socket.socket")
+    def test_closes_socket_after_success(self, mock_socket):
+        sock = mock_socket.return_value
+
+        assert check_internet_connection("example.com") is True
+
+        sock.settimeout.assert_called_once_with(5)
+        sock.connect.assert_called_once_with(("example.com", 80))
+        sock.close.assert_called_once_with()
+
+    @patch("rele.worker.socket.socket")
+    def test_closes_socket_after_connection_error(self, mock_socket):
+        sock = mock_socket.return_value
+        sock.connect.side_effect = socket.error
+
+        assert check_internet_connection("example.com") is False
+
+        sock.close.assert_called_once_with()
 
 
 @pytest.mark.usefixtures("mock_create_subscription")


### PR DESCRIPTION
Ports the regression tests from @Mirochill's #302 — as promised [in that PR](https://github.com/mercadona/rele/pull/302#issuecomment-5193835390) — and fixes the production bug they surfaced.

## The bug

```python
logger.exception("Check internet connection error", error)
```

`error` is passed as a `%`-format argument to a message with no placeholder. At format time that raises `TypeError`, `logging` swallows it via `handleError` (printing `--- Logging error ---` to stderr), and **the record is never emitted** — the diagnostic disappears exactly when connectivity fails, which is when you need it. Nothing crashes, which is why it went unnoticed since #283.

Reproduced standalone:

```
--- Logging error ---
TypeError: not all arguments converted during string formatting
Message: 'Check internet connection error'
Arguments: (OSError('connection refused'),)
```

Fix is `"...: %s"`, keeping the lazy-formatting idiom. Checked the rest of `rele/` — this was the only malformed logging call.

## The tests

@Mirochill's two tests, ported verbatim. They cover the socket being closed on both the success and `socket.error` paths, which was **untested**: the existing `check_internet_connection` tests only exercise the `api_endpoint` setting.

They're also what found the bug — pytest's `LogCaptureHandler` re-raises formatting errors instead of swallowing them, so the error-path test fails against the malformed call. Credit where it's due.

## Why `fix:` and not `test:`

I'd intended this as `test:` so it wouldn't affect the pending release, but the tests don't pass without a change to `rele/worker.py`, and mislabeling a production fix isn't worth it. This doesn't force a release either way: #329 stays open and unmerged at 1.17.1, it just gains a Bug Fixes entry.

Also adds @Mirochill to `AUTHORS.md`, and the commit carries `Co-authored-by` so the attribution shows on GitHub.

Generated with Claude Code